### PR TITLE
Add ability to not encode properties set to default values

### DIFF
--- a/src/main/kotlin/com/charleskorn/kaml/Yaml.kt
+++ b/src/main/kotlin/com/charleskorn/kaml/Yaml.kt
@@ -29,7 +29,11 @@ import kotlinx.serialization.modules.SerialModule
 import org.snakeyaml.engine.v1.api.StreamDataWriter
 import java.io.StringWriter
 
-class Yaml(val extensionDefinitionPrefix: String? = null, override val context: SerialModule = EmptyModule) : AbstractSerialFormat(context), StringFormat {
+class Yaml(
+    val extensionDefinitionPrefix: String? = null,
+    override val context: SerialModule = EmptyModule,
+    val configuration: YamlConfiguration = YamlConfiguration()
+) : AbstractSerialFormat(context), StringFormat {
     override fun <T> parse(deserializer: DeserializationStrategy<T>, string: String): T {
         val parser = YamlParser(string)
         val reader = YamlNodeReader(parser, extensionDefinitionPrefix)
@@ -45,7 +49,7 @@ class Yaml(val extensionDefinitionPrefix: String? = null, override val context: 
             override fun flush() { }
         }
 
-        val output = YamlOutput(writer)
+        val output = YamlOutput(writer, configuration)
         output.encode(serializer, obj)
 
         return writer.toString()

--- a/src/main/kotlin/com/charleskorn/kaml/YamlConfiguration.kt
+++ b/src/main/kotlin/com/charleskorn/kaml/YamlConfiguration.kt
@@ -1,0 +1,23 @@
+/*
+
+   Copyright 2019 Jonathan Bisson.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+*/
+
+package com.charleskorn.kaml
+
+data class YamlConfiguration constructor(
+    @JvmField internal val encodeDefaults: Boolean = true
+)

--- a/src/main/kotlin/com/charleskorn/kaml/YamlOutput.kt
+++ b/src/main/kotlin/com/charleskorn/kaml/YamlOutput.kt
@@ -39,7 +39,10 @@ import org.snakeyaml.engine.v1.events.SequenceStartEvent
 import org.snakeyaml.engine.v1.events.StreamStartEvent
 import java.util.Optional
 
-internal class YamlOutput(writer: StreamDataWriter) : ElementValueEncoder() {
+internal class YamlOutput(
+    writer: StreamDataWriter,
+    private val configuration: YamlConfiguration
+) : ElementValueEncoder() {
     private val settings = DumpSettingsBuilder().build()
     private val emitter = Emitter(settings, writer)
 
@@ -48,6 +51,7 @@ internal class YamlOutput(writer: StreamDataWriter) : ElementValueEncoder() {
         emitter.emit(DocumentStartEvent(false, Optional.empty(), emptyMap()))
     }
 
+    override fun shouldEncodeElementDefault(desc: SerialDescriptor, index: Int): Boolean = configuration.encodeDefaults
     override fun encodeNull() = emitPlainScalar("null")
     override fun encodeBoolean(value: Boolean) = emitPlainScalar(value.toString())
     override fun encodeByte(value: Byte) = emitPlainScalar(value.toString())

--- a/src/test/kotlin/com/charleskorn/kaml/YamlNoDefaults.kt
+++ b/src/test/kotlin/com/charleskorn/kaml/YamlNoDefaults.kt
@@ -1,0 +1,85 @@
+/*
+
+   Copyright 2018-2019 Charles Korn.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+*/
+
+package com.charleskorn.kaml
+
+import ch.tutteli.atrium.api.cc.en_GB.notToBe
+import ch.tutteli.atrium.api.cc.en_GB.toBe
+import ch.tutteli.atrium.verbs.assert
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import kotlinx.serialization.Serializable
+
+object YamlNoDefaults : Spek({
+    describe("a YAML default value") {
+        describe("testing equivalence") {
+            @Serializable
+            data class LocationLayerDefault(val line: Int, val column: Int, val layer: Int? = null)
+
+            @Serializable
+            data class LocationNoDefault(val line: Int, val column: Int)
+
+            val noDefaultEncoder = Yaml(configuration = YamlConfiguration(encodeDefaults = false))
+            val defaultEncoder = Yaml.default
+
+            val locationLayerDefaultNoEncodeDefault = noDefaultEncoder.stringify(
+                LocationLayerDefault.serializer(),
+                LocationLayerDefault(1, 1, 42)
+            )
+
+            val locationLayerNoEncodeDefault = noDefaultEncoder.stringify(
+                LocationLayerDefault.serializer(),
+                LocationLayerDefault(1, 1)
+            )
+
+            val locationLayerDefault = defaultEncoder.stringify(
+                LocationLayerDefault.serializer(),
+                LocationLayerDefault(1, 1)
+            )
+
+            val location = defaultEncoder.stringify(
+                LocationNoDefault.serializer(),
+                LocationNoDefault(1, 1)
+            )
+
+            context("compare an object with default with and without encodeDefaults") {
+                it("indicates that they are not equivalent") {
+                    assert(locationLayerDefaultNoEncodeDefault).notToBe(locationLayerNoEncodeDefault)
+                }
+            }
+
+            context("with encoding defaults: comparing an object with default overridden and object without that element") {
+                it("indicates that they are not equivalent") {
+                    assert(locationLayerDefaultNoEncodeDefault).notToBe(location)
+                }
+            }
+
+            context("with encoding defaults: comparing an object with null default and object without that element") {
+                it("indicates that they are equivalent") {
+                    assert(locationLayerNoEncodeDefault).toBe(location)
+                }
+            }
+
+            context("without encoding defaults: comparing an object with null default and object without that element") {
+                it("indicates that they are equivalent") {
+                    assert(locationLayerDefault).notToBe(locationLayerDefaultNoEncodeDefault)
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/charleskorn/kaml/YamlNoDefaults.kt
+++ b/src/test/kotlin/com/charleskorn/kaml/YamlNoDefaults.kt
@@ -1,6 +1,6 @@
 /*
 
-   Copyright 2018-2019 Charles Korn.
+   Copyright 2019 Jonathan Bisson.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
It is now possible to add a configuration option to Yaml() to tell it not to encode default values.