### PR TITLE
Migrate to kotlin 1.3.70 and kotlinx-serialization 0.20.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,12 +31,12 @@ buildscript {
     }
 
     dependencies {
-        classpath("org.jetbrains.kotlin:kotlin-serialization:1.3.61")
+        classpath("org.jetbrains.kotlin:kotlin-serialization:1.3.70")
     }
 }
 
 plugins {
-    kotlin("jvm") version "1.3.61"
+    kotlin("jvm") version "1.3.70"
 
     apply { id("com.github.ben-manes.versions") version "0.27.0" }
 }
@@ -56,7 +56,7 @@ dependencies {
 
     implementation(kotlin("stdlib-jdk8"))
     implementation(group = "org.snakeyaml", name = "snakeyaml-engine", version = "2.0")
-    implementation(group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-runtime", version = "0.14.0")
+    implementation(group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-runtime", version = "0.20.0")
 
     val spekVersion = "2.0.9"
 

--- a/src/main/kotlin/com/charleskorn/kaml/Yaml.kt
+++ b/src/main/kotlin/com/charleskorn/kaml/Yaml.kt
@@ -43,13 +43,13 @@ class Yaml(
         return input.decode(deserializer)
     }
 
-    override fun <T> stringify(serializer: SerializationStrategy<T>, obj: T): String {
+    override fun <T> stringify(serializer: SerializationStrategy<T>, value: T): String {
         val writer = object : StringWriter(), StreamDataWriter {
             override fun flush() { }
         }
 
         val output = YamlOutput(writer, context, configuration)
-        output.encode(serializer, obj)
+        output.encode(serializer, value)
 
         return writer.toString()
     }

--- a/src/main/kotlin/com/charleskorn/kaml/YamlInput.kt
+++ b/src/main/kotlin/com/charleskorn/kaml/YamlInput.kt
@@ -21,16 +21,15 @@ package com.charleskorn.kaml
 import kotlinx.serialization.CompositeDecoder
 import kotlinx.serialization.CompositeDecoder.Companion.READ_DONE
 import kotlinx.serialization.CompositeDecoder.Companion.UNKNOWN_NAME
-import kotlinx.serialization.ElementValueDecoder
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.PolymorphicKind
-import kotlinx.serialization.PrimitiveKind
 import kotlinx.serialization.SerialDescriptor
 import kotlinx.serialization.StructureKind
 import kotlinx.serialization.UpdateMode
+import kotlinx.serialization.builtins.AbstractDecoder
 import kotlinx.serialization.modules.SerialModule
 
-sealed class YamlInput(val node: YamlNode, override var context: SerialModule, val configuration: YamlConfiguration) : ElementValueDecoder() {
+sealed class YamlInput(val node: YamlNode, override var context: SerialModule, val configuration: YamlConfiguration) : AbstractDecoder() {
     companion object {
         fun createFor(node: YamlNode, context: SerialModule, configuration: YamlConfiguration): YamlInput = when (node) {
             is YamlScalar -> YamlScalarInput(node, context, configuration)
@@ -57,51 +56,55 @@ private class YamlScalarInput(val scalar: YamlScalar, context: SerialModule, con
     override fun decodeBoolean(): Boolean = scalar.toBoolean()
     override fun decodeChar(): Char = scalar.toChar()
 
-    override fun decodeEnum(enumDescription: SerialDescriptor): Int {
-        val index = enumDescription.getElementIndex(scalar.content)
+    override fun decodeEnum(enumDescriptor: SerialDescriptor): Int {
+        val index = enumDescriptor.getElementIndex(scalar.content)
 
         if (index != UNKNOWN_NAME) {
             return index
         }
 
-        val choices = (0..enumDescription.elementsCount - 1)
-            .map { enumDescription.getElementName(it) }
+        val choices = (0..enumDescriptor.elementsCount - 1)
+            .map { enumDescriptor.getElementName(it) }
             .sorted()
             .joinToString(", ")
 
         throw YamlScalarFormatException("Value ${scalar.contentToString()} is not a valid option, permitted choices are: $choices", scalar.location, scalar.content)
     }
 
-    override fun beginStructure(desc: SerialDescriptor, vararg typeParams: KSerializer<*>): CompositeDecoder {
-        when (desc.kind) {
+    override fun beginStructure(descriptor: SerialDescriptor, vararg typeParams: KSerializer<*>): CompositeDecoder {
+        when (descriptor.kind) {
             is StructureKind.MAP -> throw IncorrectTypeException("Expected a map, but got a scalar value", scalar.location)
             is StructureKind.CLASS -> throw IncorrectTypeException("Expected an object, but got a scalar value", scalar.location)
             is StructureKind.LIST -> throw IncorrectTypeException("Expected a list, but got a scalar value", scalar.location)
         }
 
-        return super.beginStructure(desc, *typeParams)
+        return super.beginStructure(descriptor, *typeParams)
     }
 
     override fun getCurrentLocation(): Location = scalar.location
+
+    override fun decodeElementIndex(descriptor: SerialDescriptor): Int = 0
 }
 
 private class YamlNullInput(val nullValue: YamlNode, context: SerialModule, configuration: YamlConfiguration) : YamlInput(nullValue, context, configuration) {
     override fun decodeNotNullMark(): Boolean = false
 
     override fun decodeValue(): Any = throw UnexpectedNullValueException(nullValue.location)
-    override fun decodeCollectionSize(desc: SerialDescriptor): Int = throw UnexpectedNullValueException(nullValue.location)
-    override fun beginStructure(desc: SerialDescriptor, vararg typeParams: KSerializer<*>): CompositeDecoder = throw UnexpectedNullValueException(nullValue.location)
+    override fun decodeCollectionSize(descriptor: SerialDescriptor): Int = throw UnexpectedNullValueException(nullValue.location)
+    override fun beginStructure(descriptor: SerialDescriptor, vararg typeParams: KSerializer<*>): CompositeDecoder = throw UnexpectedNullValueException(nullValue.location)
 
     override fun getCurrentLocation(): Location = nullValue.location
+
+    override fun decodeElementIndex(descriptor: SerialDescriptor): Int = 0
 }
 
 private class YamlListInput(val list: YamlList, context: SerialModule, configuration: YamlConfiguration) : YamlInput(list, context, configuration) {
     private var nextElementIndex = 0
     private lateinit var currentElementDecoder: YamlInput
 
-    override fun decodeCollectionSize(desc: SerialDescriptor): Int = list.items.size
+    override fun decodeCollectionSize(descriptor: SerialDescriptor): Int = list.items.size
 
-    override fun decodeElementIndex(desc: SerialDescriptor): Int {
+    override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
         if (nextElementIndex == list.items.size) {
             return READ_DONE
         }
@@ -128,7 +131,7 @@ private class YamlListInput(val list: YamlList, context: SerialModule, configura
     override fun decodeFloat(): Float = checkTypeAndDecodeFromCurrentValue("a float") { decodeFloat() }
     override fun decodeBoolean(): Boolean = checkTypeAndDecodeFromCurrentValue("a boolean") { decodeBoolean() }
     override fun decodeChar(): Char = checkTypeAndDecodeFromCurrentValue("a character") { decodeChar() }
-    override fun decodeEnum(enumDescription: SerialDescriptor): Int = checkTypeAndDecodeFromCurrentValue("an enumeration value") { decodeEnum(enumDescription) }
+    override fun decodeEnum(enumDescriptor: SerialDescriptor): Int = checkTypeAndDecodeFromCurrentValue("an enumeration value") { decodeEnum(enumDescriptor) }
 
     private fun <T> checkTypeAndDecodeFromCurrentValue(expectedTypeDescription: String, action: YamlInput.() -> T): T {
         if (!haveStartedReadingElements) {
@@ -141,15 +144,15 @@ private class YamlListInput(val list: YamlList, context: SerialModule, configura
     private val haveStartedReadingElements: Boolean
         get() = nextElementIndex > 0
 
-    override fun beginStructure(desc: SerialDescriptor, vararg typeParams: KSerializer<*>): CompositeDecoder {
+    override fun beginStructure(descriptor: SerialDescriptor, vararg typeParams: KSerializer<*>): CompositeDecoder {
         if (haveStartedReadingElements) {
-            return currentElementDecoder.beginStructure(desc, *typeParams)
+            return currentElementDecoder.beginStructure(descriptor, *typeParams)
         }
 
-        when (desc.kind) {
+        when (descriptor.kind) {
             is StructureKind.MAP -> throw IncorrectTypeException("Expected a map, but got a list", list.location)
             is StructureKind.CLASS -> throw IncorrectTypeException("Expected an object, but got a list", list.location)
-            else -> return super.beginStructure(desc, *typeParams)
+            else -> return super.beginStructure(descriptor, *typeParams)
         }
     }
 
@@ -170,8 +173,8 @@ private class YamlMapInput(val map: YamlMap, context: SerialModule, configuratio
     private lateinit var readMode: MapReadMode
     private var currentlyReadingValue: Boolean = false
 
-    override fun decodeElementIndex(desc: SerialDescriptor): Int = when (readMode) {
-        MapReadMode.Object -> decodeElementIndexForObject(desc)
+    override fun decodeElementIndex(descriptor: SerialDescriptor): Int = when (readMode) {
+        MapReadMode.Object -> decodeElementIndexForObject(descriptor)
         MapReadMode.Map -> decodeElementIndexForMap()
     }
 
@@ -250,7 +253,7 @@ private class YamlMapInput(val map: YamlMap, context: SerialModule, configuratio
     override fun decodeFloat(): Float = checkTypeAndDecodeFromCurrentValue("a float") { decodeFloat() }
     override fun decodeBoolean(): Boolean = checkTypeAndDecodeFromCurrentValue("a boolean") { decodeBoolean() }
     override fun decodeChar(): Char = checkTypeAndDecodeFromCurrentValue("a character") { decodeChar() }
-    override fun decodeEnum(enumDescription: SerialDescriptor): Int = checkTypeAndDecodeFromCurrentValue("an enumeration value") { decodeEnum(enumDescription) }
+    override fun decodeEnum(enumDescriptor: SerialDescriptor): Int = checkTypeAndDecodeFromCurrentValue("an enumeration value") { decodeEnum(enumDescriptor) }
 
     private fun <T> checkTypeAndDecodeFromCurrentValue(expectedTypeDescription: String, action: YamlInput.() -> T): T {
         if (!haveStartedReadingEntries) {
@@ -275,19 +278,19 @@ private class YamlMapInput(val map: YamlMap, context: SerialModule, configuratio
     private val haveStartedReadingEntries: Boolean
         get() = nextIndex > 0
 
-    override fun beginStructure(desc: SerialDescriptor, vararg typeParams: KSerializer<*>): CompositeDecoder {
+    override fun beginStructure(descriptor: SerialDescriptor, vararg typeParams: KSerializer<*>): CompositeDecoder {
         if (haveStartedReadingEntries) {
-            return fromCurrentValue { beginStructure(desc, *typeParams) }
+            return fromCurrentValue { beginStructure(descriptor, *typeParams) }
         }
 
-        readMode = when (desc.kind) {
+        readMode = when (descriptor.kind) {
             StructureKind.MAP -> MapReadMode.Map
-            StructureKind.CLASS, PrimitiveKind.UNIT -> MapReadMode.Object
+            StructureKind.CLASS, StructureKind.OBJECT -> MapReadMode.Object
             StructureKind.LIST -> throw IncorrectTypeException("Expected a list, but got a map", map.location)
-            else -> throw YamlException("Can't decode into ${desc.kind}", map.location)
+            else -> throw YamlException("Can't decode into ${descriptor.kind}", map.location)
         }
 
-        return super.beginStructure(desc, *typeParams)
+        return super.beginStructure(descriptor, *typeParams)
     }
 
     private enum class MapReadMode {
@@ -315,8 +318,8 @@ private class YamlTaggedInput(val taggedNode: YamlTaggedNode, context: SerialMod
 
     override fun getCurrentLocation(): Location = maybeCallOnChild(blockOnTag = taggedNode::location, blockOnChild = YamlInput::getCurrentLocation)
 
-    override fun decodeElementIndex(desc: SerialDescriptor): Int {
-        desc.calculatePolymorphic()
+    override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
+        descriptor.calculatePolymorphic()
         return when (++currentIndex) {
             0, 1 -> currentIndex
             else -> READ_DONE
@@ -335,11 +338,11 @@ private class YamlTaggedInput(val taggedNode: YamlTaggedNode, context: SerialMod
     override fun decodeDouble(): Double = maybeCallOnChild("decodeDouble", blockOnChild = YamlInput::decodeDouble)
     override fun decodeChar(): Char = maybeCallOnChild("decodeChar", blockOnChild = YamlInput::decodeChar)
     override fun decodeString(): String = maybeCallOnChild(blockOnTag = taggedNode::tag, blockOnChild = YamlInput::decodeString)
-    override fun decodeEnum(enumDescription: SerialDescriptor): Int = maybeCallOnChild("decodeEnum") { decodeEnum(enumDescription) }
+    override fun decodeEnum(enumDescriptor: SerialDescriptor): Int = maybeCallOnChild("decodeEnum") { decodeEnum(enumDescriptor) }
 
-    override fun beginStructure(desc: SerialDescriptor, vararg typeParams: KSerializer<*>): CompositeDecoder {
-        desc.calculatePolymorphic()
-        return maybeCallOnChild(blockOnTag = { super.beginStructure(desc, *typeParams) }) { beginStructure(desc, *typeParams) }
+    override fun beginStructure(descriptor: SerialDescriptor, vararg typeParams: KSerializer<*>): CompositeDecoder {
+        descriptor.calculatePolymorphic()
+        return maybeCallOnChild(blockOnTag = { super.beginStructure(descriptor, *typeParams) }) { beginStructure(descriptor, *typeParams) }
     }
 
     private fun SerialDescriptor.calculatePolymorphic() {

--- a/src/main/kotlin/com/charleskorn/kaml/YamlOutput.kt
+++ b/src/main/kotlin/com/charleskorn/kaml/YamlOutput.kt
@@ -19,13 +19,12 @@
 package com.charleskorn.kaml
 
 import kotlinx.serialization.CompositeEncoder
-import kotlinx.serialization.ElementValueEncoder
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.PrimitiveKind
 import kotlinx.serialization.SerialDescriptor
 import kotlinx.serialization.SerializationStrategy
 import kotlinx.serialization.StructureKind
+import kotlinx.serialization.builtins.AbstractEncoder
 import kotlinx.serialization.internal.AbstractPolymorphicSerializer
 import kotlinx.serialization.modules.SerialModule
 import org.snakeyaml.engine.v2.api.DumpSettings
@@ -47,7 +46,7 @@ internal class YamlOutput(
     writer: StreamDataWriter,
     override val context: SerialModule,
     private val configuration: YamlConfiguration
-) : ElementValueEncoder() {
+) : AbstractEncoder() {
     private val settings = DumpSettings.builder().build()
     private val emitter = Emitter(settings, writer)
     private var currentTag: String? = null
@@ -57,7 +56,7 @@ internal class YamlOutput(
         emitter.emit(DocumentStartEvent(false, Optional.empty(), emptyMap()))
     }
 
-    override fun shouldEncodeElementDefault(desc: SerialDescriptor, index: Int): Boolean = configuration.encodeDefaults
+    override fun shouldEncodeElementDefault(descriptor: SerialDescriptor, index: Int): Boolean = configuration.encodeDefaults
     override fun encodeNull() = emitPlainScalar("null")
     override fun encodeBoolean(value: Boolean) = emitPlainScalar(value.toString())
     override fun encodeByte(value: Byte) = emitPlainScalar(value.toString())
@@ -68,17 +67,17 @@ internal class YamlOutput(
     override fun encodeLong(value: Long) = emitPlainScalar(value.toString())
     override fun encodeShort(value: Short) = emitPlainScalar(value.toString())
     override fun encodeString(value: String) = emitQuotedScalar(value)
-    override fun encodeEnum(enumDescription: SerialDescriptor, ordinal: Int) = emitQuotedScalar(enumDescription.getElementName(ordinal))
+    override fun encodeEnum(enumDescriptor: SerialDescriptor, index: Int) = emitQuotedScalar(enumDescriptor.getElementName(index))
 
     private fun emitPlainScalar(value: String) = emitScalar(value, ScalarStyle.PLAIN)
     private fun emitQuotedScalar(value: String) = emitScalar(value, ScalarStyle.DOUBLE_QUOTED)
 
-    override fun encodeElement(desc: SerialDescriptor, index: Int): Boolean {
-        if (desc.kind is StructureKind.CLASS) {
-            emitPlainScalar(desc.getElementName(index))
+    override fun encodeElement(descriptor: SerialDescriptor, index: Int): Boolean {
+        if (descriptor.kind is StructureKind.CLASS) {
+            emitPlainScalar(descriptor.getElementName(index))
         }
 
-        return super.encodeElement(desc, index)
+        return super.encodeElement(descriptor, index)
     }
 
     @UseExperimental(InternalSerializationApi::class)
@@ -90,28 +89,26 @@ internal class YamlOutput(
 
         @Suppress("UNCHECKED_CAST")
         val actualSerializer = (serializer as AbstractPolymorphicSerializer<Any>).findPolymorphicSerializer(this, value as Any) as KSerializer<Any>
-        currentTag = actualSerializer.descriptor.name
+        currentTag = actualSerializer.descriptor.serialName
         actualSerializer.serialize(this, value)
     }
 
-    override fun beginStructure(desc: SerialDescriptor, vararg typeParams: KSerializer<*>): CompositeEncoder {
+    override fun beginStructure(descriptor: SerialDescriptor, vararg typeSerializers: KSerializer<*>): CompositeEncoder {
         val tag = getAndClearTag()
         val implicit = !tag.isPresent
-        when (desc.kind) {
+        when (descriptor.kind) {
             StructureKind.LIST -> emitter.emit(SequenceStartEvent(Optional.empty(), tag, implicit, FlowStyle.BLOCK))
-            StructureKind.MAP, StructureKind.CLASS, PrimitiveKind.UNIT -> emitter.emit(MappingStartEvent(Optional.empty(), tag, implicit, FlowStyle.BLOCK))
+            StructureKind.MAP, StructureKind.CLASS, StructureKind.OBJECT -> emitter.emit(MappingStartEvent(Optional.empty(), tag, implicit, FlowStyle.BLOCK))
         }
 
-        return super.beginStructure(desc, *typeParams)
+        return super.beginStructure(descriptor, *typeSerializers)
     }
 
-    override fun endStructure(desc: SerialDescriptor) {
-        when (desc.kind) {
+    override fun endStructure(descriptor: SerialDescriptor) {
+        when (descriptor.kind) {
             StructureKind.LIST -> emitter.emit(SequenceEndEvent())
-            StructureKind.MAP, StructureKind.CLASS, PrimitiveKind.UNIT -> emitter.emit(MappingEndEvent())
+            StructureKind.MAP, StructureKind.CLASS, StructureKind.OBJECT -> emitter.emit(MappingEndEvent())
         }
-
-        super.endStructure(desc)
     }
 
     private fun emitScalar(value: String, style: ScalarStyle) {

--- a/src/test/kotlin/com/charleskorn/kaml/YamlReadingTest.kt
+++ b/src/test/kotlin/com/charleskorn/kaml/YamlReadingTest.kt
@@ -50,21 +50,11 @@ import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialDescriptor
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Serializer
-import kotlinx.serialization.internal.BooleanSerializer
-import kotlinx.serialization.internal.ByteSerializer
-import kotlinx.serialization.internal.CharSerializer
-import kotlinx.serialization.internal.DoubleSerializer
-import kotlinx.serialization.internal.FloatSerializer
-import kotlinx.serialization.internal.IntSerializer
-import kotlinx.serialization.internal.LongSerializer
-import kotlinx.serialization.internal.ShortSerializer
-import kotlinx.serialization.internal.StringDescriptor
-import kotlinx.serialization.internal.StringSerializer
-import kotlinx.serialization.internal.nullable
-import kotlinx.serialization.list
-import kotlinx.serialization.map
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.list
+import kotlinx.serialization.builtins.nullable
+import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.modules.serializersModuleOf
-import kotlinx.serialization.serializer
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
@@ -75,7 +65,7 @@ object YamlReadingTest : Spek({
                 val input = "hello"
 
                 context("parsing that input as a string") {
-                    val result = Yaml.default.parse(StringSerializer, input)
+                    val result = Yaml.default.parse(String.serializer(), input)
 
                     it("deserializes it to the expected string value") {
                         assert(result).toBe("hello")
@@ -83,7 +73,7 @@ object YamlReadingTest : Spek({
                 }
 
                 context("parsing that input as a nullable string") {
-                    val result = Yaml.default.parse(StringSerializer.nullable, input)
+                    val result = Yaml.default.parse(String.serializer().nullable, input)
 
                     it("deserializes it to the expected string value") {
                         assert(result).toBe("hello")
@@ -143,7 +133,7 @@ object YamlReadingTest : Spek({
                 }
 
                 context("parsing that input as a float") {
-                    val result = Yaml.default.parse(FloatSerializer, input)
+                    val result = Yaml.default.parse(Float.serializer(), input)
 
                     it("deserializes it to the expected float") {
                         assert(result).toBe(123.0f)
@@ -191,7 +181,7 @@ object YamlReadingTest : Spek({
                 }
 
                 context("parsing that input as a nullable float") {
-                    val result = Yaml.default.parse(FloatSerializer.nullable, input)
+                    val result = Yaml.default.parse(Float.serializer().nullable, input)
 
                     it("deserializes it to the expected float") {
                         assert(result).toBe(123.0f)
@@ -203,7 +193,7 @@ object YamlReadingTest : Spek({
                 val input = "true"
 
                 context("parsing that input as a boolean") {
-                    val result = Yaml.default.parse(BooleanSerializer, input)
+                    val result = Yaml.default.parse(Boolean.serializer(), input)
 
                     it("deserializes it to the expected boolean value") {
                         assert(result).toBe(true)
@@ -211,7 +201,7 @@ object YamlReadingTest : Spek({
                 }
 
                 context("parsing that input as a nullable boolean") {
-                    val result = Yaml.default.parse(BooleanSerializer.nullable, input)
+                    val result = Yaml.default.parse(Boolean.serializer().nullable, input)
 
                     it("deserializes it to the expected boolean value") {
                         assert(result).toBe(true)
@@ -223,7 +213,7 @@ object YamlReadingTest : Spek({
                 val input = "c"
 
                 context("parsing that input as a character") {
-                    val result = Yaml.default.parse(CharSerializer, input)
+                    val result = Yaml.default.parse(Char.serializer(), input)
 
                     it("deserializes it to the expected character value") {
                         assert(result).toBe('c')
@@ -231,7 +221,7 @@ object YamlReadingTest : Spek({
                 }
 
                 context("parsing that input as a nullable character") {
-                    val result = Yaml.default.parse(CharSerializer.nullable, input)
+                    val result = Yaml.default.parse(Char.serializer().nullable, input)
 
                     it("deserializes it to the expected character value") {
                         assert(result).toBe('c')
@@ -269,7 +259,7 @@ object YamlReadingTest : Spek({
             val input = "null"
 
             context("parsing a null value as a nullable string") {
-                val result = Yaml.default.parse(StringSerializer.nullable, input)
+                val result = Yaml.default.parse(String.serializer().nullable, input)
 
                 it("returns a null value") {
                     assert(result).toBe(null)
@@ -278,7 +268,7 @@ object YamlReadingTest : Spek({
 
             context("parsing a null value as a non-nullable string") {
                 it("throws an appropriate exception") {
-                    assert({ Yaml.default.parse(StringSerializer, input) }).toThrow<UnexpectedNullValueException> {
+                    assert({ Yaml.default.parse(String.serializer(), input) }).toThrow<UnexpectedNullValueException> {
                         message { toBe("Unexpected null or empty value for non-null field.") }
                         line { toBe(1) }
                         column { toBe(1) }
@@ -287,7 +277,7 @@ object YamlReadingTest : Spek({
             }
 
             context("parsing a null value as a nullable integer") {
-                val result = Yaml.default.parse(IntSerializer.nullable, input)
+                val result = Yaml.default.parse(Int.serializer().nullable, input)
 
                 it("returns a null value") {
                     assert(result).toBe(null)
@@ -296,7 +286,7 @@ object YamlReadingTest : Spek({
 
             context("parsing a null value as a non-nullable integer") {
                 it("throws an appropriate exception") {
-                    assert({ Yaml.default.parse(IntSerializer, input) }).toThrow<UnexpectedNullValueException> {
+                    assert({ Yaml.default.parse(Int.serializer(), input) }).toThrow<UnexpectedNullValueException> {
                         message { toBe("Unexpected null or empty value for non-null field.") }
                         line { toBe(1) }
                         column { toBe(1) }
@@ -305,7 +295,7 @@ object YamlReadingTest : Spek({
             }
 
             context("parsing a null value as a nullable long") {
-                val result = Yaml.default.parse(LongSerializer.nullable, input)
+                val result = Yaml.default.parse(Long.serializer().nullable, input)
 
                 it("returns a null value") {
                     assert(result).toBe(null)
@@ -314,7 +304,7 @@ object YamlReadingTest : Spek({
 
             context("parsing a null value as a non-nullable long") {
                 it("throws an appropriate exception") {
-                    assert({ Yaml.default.parse(LongSerializer, input) }).toThrow<UnexpectedNullValueException> {
+                    assert({ Yaml.default.parse(Long.serializer(), input) }).toThrow<UnexpectedNullValueException> {
                         message { toBe("Unexpected null or empty value for non-null field.") }
                         line { toBe(1) }
                         column { toBe(1) }
@@ -323,7 +313,7 @@ object YamlReadingTest : Spek({
             }
 
             context("parsing a null value as a nullable short") {
-                val result = Yaml.default.parse(ShortSerializer.nullable, input)
+                val result = Yaml.default.parse(Short.serializer().nullable, input)
 
                 it("returns a null value") {
                     assert(result).toBe(null)
@@ -332,7 +322,7 @@ object YamlReadingTest : Spek({
 
             context("parsing a null value as a non-nullable short") {
                 it("throws an appropriate exception") {
-                    assert({ Yaml.default.parse(ShortSerializer, input) }).toThrow<UnexpectedNullValueException> {
+                    assert({ Yaml.default.parse(Short.serializer(), input) }).toThrow<UnexpectedNullValueException> {
                         message { toBe("Unexpected null or empty value for non-null field.") }
                         line { toBe(1) }
                         column { toBe(1) }
@@ -341,7 +331,7 @@ object YamlReadingTest : Spek({
             }
 
             context("parsing a null value as a nullable byte") {
-                val result = Yaml.default.parse(ByteSerializer.nullable, input)
+                val result = Yaml.default.parse(Byte.serializer().nullable, input)
 
                 it("returns a null value") {
                     assert(result).toBe(null)
@@ -350,7 +340,7 @@ object YamlReadingTest : Spek({
 
             context("parsing a null value as a non-nullable byte") {
                 it("throws an appropriate exception") {
-                    assert({ Yaml.default.parse(ByteSerializer, input) }).toThrow<UnexpectedNullValueException> {
+                    assert({ Yaml.default.parse(Byte.serializer(), input) }).toThrow<UnexpectedNullValueException> {
                         message { toBe("Unexpected null or empty value for non-null field.") }
                         line { toBe(1) }
                         column { toBe(1) }
@@ -359,7 +349,7 @@ object YamlReadingTest : Spek({
             }
 
             context("parsing a null value as a nullable double") {
-                val result = Yaml.default.parse(DoubleSerializer.nullable, input)
+                val result = Yaml.default.parse(Double.serializer().nullable, input)
 
                 it("returns a null value") {
                     assert(result).toBe(null)
@@ -368,7 +358,7 @@ object YamlReadingTest : Spek({
 
             context("parsing a null value as a non-nullable double") {
                 it("throws an appropriate exception") {
-                    assert({ Yaml.default.parse(DoubleSerializer, input) }).toThrow<UnexpectedNullValueException> {
+                    assert({ Yaml.default.parse(Double.serializer(), input) }).toThrow<UnexpectedNullValueException> {
                         message { toBe("Unexpected null or empty value for non-null field.") }
                         line { toBe(1) }
                         column { toBe(1) }
@@ -377,7 +367,7 @@ object YamlReadingTest : Spek({
             }
 
             context("parsing a null value as a nullable float") {
-                val result = Yaml.default.parse(FloatSerializer.nullable, input)
+                val result = Yaml.default.parse(Float.serializer().nullable, input)
 
                 it("returns a null value") {
                     assert(result).toBe(null)
@@ -386,7 +376,7 @@ object YamlReadingTest : Spek({
 
             context("parsing a null value as a non-nullable float") {
                 it("throws an appropriate exception") {
-                    assert({ Yaml.default.parse(FloatSerializer, input) }).toThrow<UnexpectedNullValueException> {
+                    assert({ Yaml.default.parse(Float.serializer(), input) }).toThrow<UnexpectedNullValueException> {
                         message { toBe("Unexpected null or empty value for non-null field.") }
                         line { toBe(1) }
                         column { toBe(1) }
@@ -395,7 +385,7 @@ object YamlReadingTest : Spek({
             }
 
             context("parsing a null value as a nullable boolean") {
-                val result = Yaml.default.parse(BooleanSerializer.nullable, input)
+                val result = Yaml.default.parse(Boolean.serializer().nullable, input)
 
                 it("returns a null value") {
                     assert(result).toBe(null)
@@ -404,7 +394,7 @@ object YamlReadingTest : Spek({
 
             context("parsing a null value as a non-nullable boolean") {
                 it("throws an appropriate exception") {
-                    assert({ Yaml.default.parse(BooleanSerializer, input) }).toThrow<UnexpectedNullValueException> {
+                    assert({ Yaml.default.parse(Boolean.serializer(), input) }).toThrow<UnexpectedNullValueException> {
                         message { toBe("Unexpected null or empty value for non-null field.") }
                         line { toBe(1) }
                         column { toBe(1) }
@@ -413,7 +403,7 @@ object YamlReadingTest : Spek({
             }
 
             context("parsing a null value as a nullable character") {
-                val result = Yaml.default.parse(CharSerializer.nullable, input)
+                val result = Yaml.default.parse(Char.serializer().nullable, input)
 
                 it("returns a null value") {
                     assert(result).toBe(null)
@@ -422,7 +412,7 @@ object YamlReadingTest : Spek({
 
             context("parsing a null value as a non-nullable character") {
                 it("throws an appropriate exception") {
-                    assert({ Yaml.default.parse(CharSerializer, input) }).toThrow<UnexpectedNullValueException> {
+                    assert({ Yaml.default.parse(Char.serializer(), input) }).toThrow<UnexpectedNullValueException> {
                         message { toBe("Unexpected null or empty value for non-null field.") }
                         line { toBe(1) }
                         column { toBe(1) }
@@ -449,7 +439,7 @@ object YamlReadingTest : Spek({
             }
 
             context("parsing a null value as a nullable list") {
-                val result = Yaml.default.parse(StringSerializer.list.nullable, input)
+                val result = Yaml.default.parse(String.serializer().list.nullable, input)
 
                 it("returns a null value") {
                     assert(result).toBe(null)
@@ -458,7 +448,7 @@ object YamlReadingTest : Spek({
 
             context("parsing a null value as a non-nullable list") {
                 it("throws an appropriate exception") {
-                    assert({ Yaml.default.parse(StringSerializer.list, input) }).toThrow<UnexpectedNullValueException> {
+                    assert({ Yaml.default.parse(String.serializer().list, input) }).toThrow<UnexpectedNullValueException> {
                         message { toBe("Unexpected null or empty value for non-null field.") }
                         line { toBe(1) }
                         column { toBe(1) }
@@ -574,7 +564,7 @@ object YamlReadingTest : Spek({
                 }
 
                 context("parsing that input as a list of floats") {
-                    val result = Yaml.default.parse(FloatSerializer.list, input)
+                    val result = Yaml.default.parse(Float.serializer().list, input)
 
                     it("deserializes it to the expected value") {
                         assert(result).toBe(listOf(123.0f, 45.0f, 6.0f))
@@ -619,7 +609,7 @@ object YamlReadingTest : Spek({
                 """.trimIndent()
 
                 context("parsing that input as a list") {
-                    val result = Yaml.default.parse(CharSerializer.list, input)
+                    val result = Yaml.default.parse(Char.serializer().list, input)
 
                     it("deserializes it to the expected value") {
                         assert(result).toBe(listOf('a', 'b'))
@@ -861,7 +851,7 @@ object YamlReadingTest : Spek({
                 }
 
                 context("parsing that input as map") {
-                    val result = Yaml.default.parse((StringSerializer to (StringSerializer to IntSerializer).map).map, input)
+                    val result = Yaml.default.parse(MapSerializer(String.serializer(), MapSerializer(String.serializer(), Int.serializer())), input)
                     it("deserializes it to a Map ignoring the tag") {
                         assert(result).toBe(mapOf("element" to mapOf("value" to 3)))
                     }
@@ -876,7 +866,7 @@ object YamlReadingTest : Spek({
                 """.trimIndent()
 
                 context("parsing that input as list") {
-                    val result = Yaml.default.parse(IntSerializer.list, input)
+                    val result = Yaml.default.parse(Int.serializer().list, input)
                     it("deserializes it to a list ignoring the tag") {
                         assert(result).toBe(listOf(5, 3))
                     }
@@ -898,7 +888,8 @@ object YamlReadingTest : Spek({
                 """.trimIndent()
 
                 context("parsing that input as map") {
-                    val result = Yaml.default.parse((StringSerializer to StringSerializer).map, input)
+                    val result = Yaml.default.parse(MapSerializer
+                        (String.serializer(), String.serializer()), input)
                     it("deserializes it to a Map ignoring the tag") {
                         assert(result).toBe(mapOf("foo" to "bar"))
                     }
@@ -1225,7 +1216,7 @@ object YamlReadingTest : Spek({
                 """.trimIndent()
 
                 context("parsing that input") {
-                    val result = Yaml.default.parse((StringSerializer to StringSerializer).map, input)
+                    val result = Yaml.default.parse(MapSerializer(String.serializer(), String.serializer()), input)
 
                     it("deserializes it to a Kotlin map") {
                         assert(result).toBe(
@@ -1239,7 +1230,7 @@ object YamlReadingTest : Spek({
 
                 context("parsing that input with a serializer for the key that uses YAML location information when throwing exceptions") {
                     it("throws an exception with the correct location information") {
-                        assert({ Yaml.default.parse((LocationThrowingSerializer to StringSerializer).map, input) }).toThrow<LocationInformationException> {
+                        assert({ Yaml.default.parse(MapSerializer(LocationThrowingSerializer, String.serializer()), input) }).toThrow<LocationInformationException> {
                             message { toBe("Serializer called with location: 1, 1") }
                         }
                     }
@@ -1247,7 +1238,7 @@ object YamlReadingTest : Spek({
 
                 context("parsing that input with a serializer for the value that uses YAML location information when throwing exceptions") {
                     it("throws an exception with the correct location information") {
-                        assert({ Yaml.default.parse((StringSerializer to LocationThrowingSerializer).map, input) }).toThrow<LocationInformationException> {
+                        assert({ Yaml.default.parse(MapSerializer(String.serializer(), LocationThrowingSerializer), input) }).toThrow<LocationInformationException> {
                             message { toBe("Serializer called with location: 1, 15") }
                         }
                     }
@@ -1329,7 +1320,7 @@ object YamlReadingTest : Spek({
 
             val contextSerializer = object : KSerializer<Inner> {
                 override val descriptor: SerialDescriptor
-                    get() = StringDescriptor
+                    get() = String.serializer().descriptor
 
                 override fun deserialize(decoder: Decoder): Inner = Inner("from context serializer")
                 override fun serialize(encoder: Encoder, obj: Inner) = throw UnsupportedOperationException()
@@ -1354,19 +1345,19 @@ object YamlReadingTest : Spek({
         describe("parsing values with mismatched types") {
             context("given a list") {
                 listOf(
-                    "a string" to StringSerializer,
-                    "an integer" to IntSerializer,
-                    "a long" to LongSerializer,
-                    "a short" to ShortSerializer,
-                    "a byte" to ByteSerializer,
-                    "a double" to DoubleSerializer,
-                    "a float" to FloatSerializer,
-                    "a boolean" to BooleanSerializer,
-                    "a character" to CharSerializer,
+                    "a string" to String.serializer(),
+                    "an integer" to Int.serializer(),
+                    "a long" to Long.serializer(),
+                    "a short" to Short.serializer(),
+                    "a byte" to Byte.serializer(),
+                    "a double" to Double.serializer(),
+                    "a float" to Float.serializer(),
+                    "a boolean" to Boolean.serializer(),
+                    "a character" to Char.serializer(),
                     "an enumeration value" to TestEnum.serializer(),
-                    "a map" to (StringSerializer to StringSerializer).map,
+                    "a map" to MapSerializer(String.serializer(), String.serializer()),
                     "an object" to ComplexStructure.serializer(),
-                    "a string" to StringSerializer.nullable
+                    "a string" to String.serializer().nullable
                 ).forEach { (description, serializer) ->
                     val input = "- thing"
 
@@ -1388,7 +1379,7 @@ object YamlReadingTest : Spek({
                     """.trimIndent()
 
                     it("throws an exception with the correct location information") {
-                        assert({ Yaml.default.parse((StringSerializer to StringSerializer).map, input) }).toThrow<InvalidPropertyValueException> {
+                        assert({ Yaml.default.parse(MapSerializer(String.serializer(), String.serializer()), input) }).toThrow<InvalidPropertyValueException> {
                             message { toBe("Value for 'key' is invalid: Expected a string, but got a list") }
                             line { toBe(2) }
                             column { toBe(5) }
@@ -1417,7 +1408,7 @@ object YamlReadingTest : Spek({
                     """.trimIndent()
 
                     it("throws an exception with the correct location information") {
-                        assert({ Yaml.default.parse(StringSerializer.list, input) }).toThrow<IncorrectTypeException> {
+                        assert({ Yaml.default.parse(String.serializer().list, input) }).toThrow<IncorrectTypeException> {
                             message { toBe("Expected a string, but got a list") }
                             line { toBe(1) }
                             column { toBe(3) }
@@ -1428,18 +1419,18 @@ object YamlReadingTest : Spek({
 
             context("given a map") {
                 listOf(
-                    "a string" to StringSerializer,
-                    "an integer" to IntSerializer,
-                    "a long" to LongSerializer,
-                    "a short" to ShortSerializer,
-                    "a byte" to ByteSerializer,
-                    "a double" to DoubleSerializer,
-                    "a float" to FloatSerializer,
-                    "a boolean" to BooleanSerializer,
-                    "a character" to CharSerializer,
+                    "a string" to String.serializer(),
+                    "an integer" to Int.serializer(),
+                    "a long" to Long.serializer(),
+                    "a short" to Short.serializer(),
+                    "a byte" to Byte.serializer(),
+                    "a double" to Double.serializer(),
+                    "a float" to Float.serializer(),
+                    "a boolean" to Boolean.serializer(),
+                    "a character" to Char.serializer(),
                     "an enumeration value" to TestEnum.serializer(),
-                    "a list" to StringSerializer.list,
-                    "a string" to StringSerializer.nullable
+                    "a list" to String.serializer().list,
+                    "a string" to String.serializer().nullable
                 ).forEach { (description, serializer) ->
                     val input = "key: value"
 
@@ -1461,7 +1452,7 @@ object YamlReadingTest : Spek({
                     """.trimIndent()
 
                     it("throws an exception with the correct location information") {
-                        assert({ Yaml.default.parse((StringSerializer to StringSerializer).map, input) }).toThrow<InvalidPropertyValueException> {
+                        assert({ Yaml.default.parse(MapSerializer(String.serializer(), String.serializer()), input) }).toThrow<InvalidPropertyValueException> {
                             message { toBe("Value for 'key' is invalid: Expected a string, but got a map") }
                             line { toBe(2) }
                             column { toBe(5) }
@@ -1490,7 +1481,7 @@ object YamlReadingTest : Spek({
                     """.trimIndent()
 
                     it("throws an exception with the correct location information") {
-                        assert({ Yaml.default.parse(StringSerializer.list, input) }).toThrow<IncorrectTypeException> {
+                        assert({ Yaml.default.parse(String.serializer().list, input) }).toThrow<IncorrectTypeException> {
                             message { toBe("Expected a string, but got a map") }
                             line { toBe(1) }
                             column { toBe(3) }
@@ -1501,8 +1492,8 @@ object YamlReadingTest : Spek({
 
             context("given a scalar value") {
                 mapOf(
-                    "a list" to StringSerializer.list,
-                    "a map" to (StringSerializer to StringSerializer).map,
+                    "a list" to String.serializer().list,
+                    "a map" to MapSerializer(String.serializer(), String.serializer()),
                     "an object" to ComplexStructure.serializer()
                 ).forEach { description, serializer ->
                     val input = "blah"
@@ -1524,7 +1515,7 @@ object YamlReadingTest : Spek({
                     """.trimIndent()
 
                     it("throws an exception with the correct location information") {
-                        assert({ Yaml.default.parse((StringSerializer to StringSerializer.list).map, input) }).toThrow<InvalidPropertyValueException> {
+                        assert({ Yaml.default.parse(MapSerializer(String.serializer(), String.serializer().list), input) }).toThrow<InvalidPropertyValueException> {
                             message { toBe("Value for 'key' is invalid: Expected a list, but got a scalar value") }
                             line { toBe(1) }
                             column { toBe(6) }
@@ -1552,7 +1543,7 @@ object YamlReadingTest : Spek({
                     """.trimIndent()
 
                     it("throws an exception with the correct location information") {
-                        assert({ Yaml.default.parse((StringSerializer.list).list, input) }).toThrow<IncorrectTypeException> {
+                        assert({ Yaml.default.parse((String.serializer().list).list, input) }).toThrow<IncorrectTypeException> {
                             message { toBe("Expected a list, but got a scalar value") }
                             line { toBe(1) }
                             column { toBe(3) }
@@ -1589,7 +1580,7 @@ private data class CustomSerializedValue(val thing: String)
 @Serializer(forClass = CustomSerializedValue::class)
 private object LocationThrowingSerializer : KSerializer<CustomSerializedValue> {
     override val descriptor: SerialDescriptor
-        get() = StringDescriptor
+        get() = String.serializer().descriptor
 
     override fun deserialize(decoder: Decoder): CustomSerializedValue {
         val location = (decoder as YamlInput).getCurrentLocation()
@@ -1597,7 +1588,7 @@ private object LocationThrowingSerializer : KSerializer<CustomSerializedValue> {
         throw LocationInformationException("Serializer called with location: ${location.line}, ${location.column}")
     }
 
-    override fun serialize(encoder: Encoder, obj: CustomSerializedValue) = throw UnsupportedOperationException()
+    override fun serialize(encoder: Encoder, value: CustomSerializedValue) = throw UnsupportedOperationException()
 }
 
 private class LocationInformationException(message: String) : RuntimeException(message)

--- a/src/test/kotlin/com/charleskorn/kaml/YamlWritingTest.kt
+++ b/src/test/kotlin/com/charleskorn/kaml/YamlWritingTest.kt
@@ -42,18 +42,10 @@ import com.charleskorn.kaml.testobjects.TestEnum
 import com.charleskorn.kaml.testobjects.TestSealedStructure
 import com.charleskorn.kaml.testobjects.simpleModule
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.internal.BooleanSerializer
-import kotlinx.serialization.internal.ByteSerializer
-import kotlinx.serialization.internal.CharSerializer
-import kotlinx.serialization.internal.DoubleSerializer
-import kotlinx.serialization.internal.FloatSerializer
-import kotlinx.serialization.internal.IntSerializer
-import kotlinx.serialization.internal.LongSerializer
-import kotlinx.serialization.internal.ShortSerializer
-import kotlinx.serialization.internal.StringSerializer
-import kotlinx.serialization.internal.nullable
-import kotlinx.serialization.list
-import kotlinx.serialization.map
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.builtins.list
+import kotlinx.serialization.builtins.nullable
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
@@ -63,7 +55,7 @@ object YamlWritingTest : Spek({
             val input = null as String?
 
             context("serializing a null string value") {
-                val output = Yaml.default.stringify(StringSerializer.nullable, input)
+                val output = Yaml.default.stringify(String.serializer().nullable, input)
 
                 it("returns the value serialized in the expected YAML form") {
                     assert(output).toBe("null")
@@ -73,7 +65,7 @@ object YamlWritingTest : Spek({
 
         describe("serializing boolean values") {
             context("serializing a true value") {
-                val output = Yaml.default.stringify(BooleanSerializer, true)
+                val output = Yaml.default.stringify(Boolean.serializer(), true)
 
                 it("returns the value serialized in the expected YAML form") {
                     assert(output).toBe("true")
@@ -81,7 +73,7 @@ object YamlWritingTest : Spek({
             }
 
             context("serializing a false value") {
-                val output = Yaml.default.stringify(BooleanSerializer, false)
+                val output = Yaml.default.stringify(Boolean.serializer(), false)
 
                 it("returns the value serialized in the expected YAML form") {
                     assert(output).toBe("false")
@@ -90,7 +82,7 @@ object YamlWritingTest : Spek({
         }
 
         describe("serializing byte values") {
-            val output = Yaml.default.stringify(ByteSerializer, 12)
+            val output = Yaml.default.stringify(Byte.serializer(), 12)
 
             it("returns the value serialized in the expected YAML form") {
                 assert(output).toBe("12")
@@ -99,7 +91,7 @@ object YamlWritingTest : Spek({
 
         describe("serializing character values") {
             context("serializing a alphanumeric character") {
-                val output = Yaml.default.stringify(CharSerializer, 'A')
+                val output = Yaml.default.stringify(Char.serializer(), 'A')
 
                 it("returns the value serialized in the expected YAML form") {
                     assert(output).toBe(""""A"""")
@@ -107,7 +99,7 @@ object YamlWritingTest : Spek({
             }
 
             context("serializing a double-quote character") {
-                val output = Yaml.default.stringify(CharSerializer, '"')
+                val output = Yaml.default.stringify(Char.serializer(), '"')
 
                 it("returns the value serialized in the expected YAML form, escaping the double-quote character") {
                     assert(output).toBe(""""\""""")
@@ -115,7 +107,7 @@ object YamlWritingTest : Spek({
             }
 
             context("serializing a newline character") {
-                val output = Yaml.default.stringify(CharSerializer, '\n')
+                val output = Yaml.default.stringify(Char.serializer(), '\n')
 
                 it("returns the value serialized in the expected YAML form, escaping the newline character") {
                     assert(output).toBe(""""\n"""")
@@ -124,7 +116,7 @@ object YamlWritingTest : Spek({
         }
 
         describe("serializing double values") {
-            val output = Yaml.default.stringify(DoubleSerializer, 12.3)
+            val output = Yaml.default.stringify(Double.serializer(), 12.3)
 
             it("returns the value serialized in the expected YAML form") {
                 assert(output).toBe("12.3")
@@ -132,7 +124,7 @@ object YamlWritingTest : Spek({
         }
 
         describe("serializing floating point values") {
-            val output = Yaml.default.stringify(FloatSerializer, 45.6f)
+            val output = Yaml.default.stringify(Float.serializer(), 45.6f)
 
             it("returns the value serialized in the expected YAML form") {
                 assert(output).toBe("45.6")
@@ -140,7 +132,7 @@ object YamlWritingTest : Spek({
         }
 
         describe("serializing integer values") {
-            val output = Yaml.default.stringify(IntSerializer, 12)
+            val output = Yaml.default.stringify(Int.serializer(), 12)
 
             it("returns the value serialized in the expected YAML form") {
                 assert(output).toBe("12")
@@ -148,7 +140,7 @@ object YamlWritingTest : Spek({
         }
 
         describe("serializing long integer values") {
-            val output = Yaml.default.stringify(LongSerializer, 12)
+            val output = Yaml.default.stringify(Long.serializer(), 12)
 
             it("returns the value serialized in the expected YAML form") {
                 assert(output).toBe("12")
@@ -156,7 +148,7 @@ object YamlWritingTest : Spek({
         }
 
         describe("serializing short integer values") {
-            val output = Yaml.default.stringify(ShortSerializer, 12)
+            val output = Yaml.default.stringify(Short.serializer(), 12)
 
             it("returns the value serialized in the expected YAML form") {
                 assert(output).toBe("12")
@@ -165,7 +157,7 @@ object YamlWritingTest : Spek({
 
         describe("serializing string values") {
             context("serializing a string without any special characters") {
-                val output = Yaml.default.stringify(StringSerializer, "hello world")
+                val output = Yaml.default.stringify(String.serializer(), "hello world")
 
                 it("returns the value serialized in the expected YAML form") {
                     assert(output).toBe(""""hello world"""")
@@ -173,7 +165,7 @@ object YamlWritingTest : Spek({
             }
 
             context("serializing an empty string") {
-                val output = Yaml.default.stringify(StringSerializer, "")
+                val output = Yaml.default.stringify(String.serializer(), "")
 
                 it("returns the value serialized in the expected YAML form") {
                     assert(output).toBe("""""""")
@@ -181,7 +173,7 @@ object YamlWritingTest : Spek({
             }
 
             context("serializing the string 'null'") {
-                val output = Yaml.default.stringify(StringSerializer, "null")
+                val output = Yaml.default.stringify(String.serializer(), "null")
 
                 it("returns the value serialized in the expected YAML form") {
                     assert(output).toBe(""""null"""")
@@ -189,7 +181,7 @@ object YamlWritingTest : Spek({
             }
 
             context("serializing a multi-line string") {
-                val output = Yaml.default.stringify(StringSerializer, "This is line 1\nThis is line 2")
+                val output = Yaml.default.stringify(String.serializer(), "This is line 1\nThis is line 2")
 
                 it("returns the value serialized in the expected YAML form, escaping the newline character") {
                     assert(output).toBe(""""This is line 1\nThis is line 2"""")
@@ -197,7 +189,7 @@ object YamlWritingTest : Spek({
             }
 
             context("serializing a string containing a double-quote character") {
-                val output = Yaml.default.stringify(StringSerializer, """They said "hello" to me""")
+                val output = Yaml.default.stringify(String.serializer(), """They said "hello" to me""")
 
                 it("returns the value serialized in the expected YAML form, escaping the double-quote characters") {
                     assert(output).toBe(""""They said \"hello\" to me"""")
@@ -215,7 +207,7 @@ object YamlWritingTest : Spek({
 
         describe("serializing lists") {
             context("serializing a list of integers") {
-                val output = Yaml.default.stringify(IntSerializer.list, listOf(1, 2, 3))
+                val output = Yaml.default.stringify(Int.serializer().list, listOf(1, 2, 3))
 
                 it("returns the value serialized in the expected YAML form") {
                     assert(output).toBe(
@@ -229,7 +221,7 @@ object YamlWritingTest : Spek({
             }
 
             context("serializing a list of nullable integers") {
-                val output = Yaml.default.stringify(IntSerializer.nullable.list, listOf(1, null, 3))
+                val output = Yaml.default.stringify(Int.serializer().nullable.list, listOf(1, null, 3))
 
                 it("returns the value serialized in the expected YAML form") {
                     assert(output).toBe(
@@ -243,7 +235,7 @@ object YamlWritingTest : Spek({
             }
 
             context("serializing a list of strings") {
-                val output = Yaml.default.stringify(StringSerializer.list, listOf("item1", "item2"))
+                val output = Yaml.default.stringify(String.serializer().list, listOf("item1", "item2"))
 
                 it("returns the value serialized in the expected YAML form") {
                     assert(output).toBe(
@@ -261,7 +253,7 @@ object YamlWritingTest : Spek({
                     listOf(4, 5)
                 )
 
-                val output = Yaml.default.stringify(IntSerializer.list.list, input)
+                val output = Yaml.default.stringify(Int.serializer().list.list, input)
 
                 it("returns the value serialized in the expected YAML form") {
                     assert(output).toBe(
@@ -287,7 +279,7 @@ object YamlWritingTest : Spek({
                     )
                 )
 
-                val serializer = (StringSerializer to StringSerializer).map.list
+                val serializer = MapSerializer(String.serializer(), String.serializer()).list
                 val output = Yaml.default.stringify(serializer, input)
 
                 it("returns the value serialized in the expected YAML form") {
@@ -327,7 +319,7 @@ object YamlWritingTest : Spek({
                     "key2" to "value2"
                 )
 
-                val output = Yaml.default.stringify((StringSerializer to StringSerializer).map, input)
+                val output = Yaml.default.stringify(MapSerializer(String.serializer(), String.serializer()), input)
 
                 it("returns the value serialized in the expected YAML form") {
                     assert(output).toBe(
@@ -350,7 +342,7 @@ object YamlWritingTest : Spek({
                     )
                 )
 
-                val serializer = (StringSerializer to (StringSerializer to StringSerializer).map).map
+                val serializer = MapSerializer(String.serializer(), MapSerializer(String.serializer(), String.serializer()))
                 val output = Yaml.default.stringify(serializer, input)
 
                 it("returns the value serialized in the expected YAML form") {
@@ -372,7 +364,7 @@ object YamlWritingTest : Spek({
                     "list2" to listOf(4, 5, 6)
                 )
 
-                val serializer = (StringSerializer to IntSerializer.list).map
+                val serializer = MapSerializer(String.serializer(), Int.serializer().list)
                 val output = Yaml.default.stringify(serializer, input)
 
                 it("returns the value serialized in the expected YAML form") {
@@ -397,7 +389,7 @@ object YamlWritingTest : Spek({
                     "item2" to SimpleStructure("name2")
                 )
 
-                val serializer = (StringSerializer to SimpleStructure.serializer()).map
+                val serializer = MapSerializer(String.serializer(), SimpleStructure.serializer())
                 val output = Yaml.default.stringify(serializer, input)
 
                 it("returns the value serialized in the expected YAML form") {

--- a/src/test/kotlin/com/charleskorn/kaml/testobjects/PolymorphicTestObjects.kt
+++ b/src/test/kotlin/com/charleskorn/kaml/testobjects/PolymorphicTestObjects.kt
@@ -24,17 +24,9 @@ import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialDescriptor
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.internal.BooleanSerializer
-import kotlinx.serialization.internal.ByteSerializer
-import kotlinx.serialization.internal.CharSerializer
-import kotlinx.serialization.internal.DoubleSerializer
-import kotlinx.serialization.internal.FloatSerializer
-import kotlinx.serialization.internal.IntSerializer
-import kotlinx.serialization.internal.LongSerializer
-import kotlinx.serialization.internal.ShortSerializer
-import kotlinx.serialization.internal.StringSerializer
-import kotlinx.serialization.internal.UnitSerializer
-import kotlinx.serialization.internal.nullable
+import kotlinx.serialization.builtins.UnitSerializer
+import kotlinx.serialization.builtins.nullable
+import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.modules.SerializersModule
 
 @Serializable
@@ -54,72 +46,72 @@ data class SealedWrapper(val element: TestSealedStructure?)
 interface SimpleInterface
 
 object SimpleNull : SimpleInterface {
-    val kSerializer: KSerializer<SimpleNull> = UnitSerializer.nullable.mapped("simpleNull", { SimpleNull }, { null })
+    val kSerializer: KSerializer<SimpleNull> = UnitSerializer().nullable.mapped("simpleNull", { SimpleNull }, { null })
 }
 
 data class SimpleUnit(val data: Unit) : SimpleInterface {
     companion object {
-        val kSerializer = UnitSerializer.mapped("simpleUnit", ::SimpleUnit, SimpleUnit::data)
+        val kSerializer = UnitSerializer().mapped("simpleUnit", ::SimpleUnit, SimpleUnit::data)
     }
 }
 
 data class SimpleBoolean(val data: Boolean) : SimpleInterface {
     companion object {
-        val kSerializer = BooleanSerializer.mapped("simpleBoolean", ::SimpleBoolean, SimpleBoolean::data)
+        val kSerializer = Boolean.serializer().mapped("simpleBoolean", ::SimpleBoolean, SimpleBoolean::data)
     }
 }
 
 data class SimpleByte(val data: Byte) : SimpleInterface {
     companion object {
-        val kSerializer = ByteSerializer.mapped("simpleByte", ::SimpleByte, SimpleByte::data)
+        val kSerializer = Byte.serializer().mapped("simpleByte", ::SimpleByte, SimpleByte::data)
     }
 }
 
 data class SimpleShort(val data: Short) : SimpleInterface {
     companion object {
-        val kSerializer = ShortSerializer.mapped("simpleShort", ::SimpleShort, SimpleShort::data)
+        val kSerializer = Short.serializer().mapped("simpleShort", ::SimpleShort, SimpleShort::data)
     }
 }
 
 data class SimpleInt(val data: Int) : SimpleInterface {
     companion object {
-        val kSerializer = IntSerializer.mapped("simpleInt", ::SimpleInt, SimpleInt::data)
+        val kSerializer = Int.serializer().mapped("simpleInt", ::SimpleInt, SimpleInt::data)
     }
 }
 
 data class SimpleNullableInt(val data: Int?) : SimpleInterface {
     companion object {
-        val kSerializer = IntSerializer.nullable.mapped("simpleNullableInt", ::SimpleNullableInt, SimpleNullableInt::data)
+        val kSerializer = Int.serializer().nullable.mapped("simpleNullableInt", ::SimpleNullableInt, SimpleNullableInt::data)
     }
 }
 
 data class SimpleLong(val data: Long) : SimpleInterface {
     companion object {
-        val kSerializer = LongSerializer.mapped("simpleLong", ::SimpleLong, SimpleLong::data)
+        val kSerializer = Long.serializer().mapped("simpleLong", ::SimpleLong, SimpleLong::data)
     }
 }
 
 data class SimpleFloat(val data: Float) : SimpleInterface {
     companion object {
-        val kSerializer = FloatSerializer.mapped("simpleFloat", ::SimpleFloat, SimpleFloat::data)
+        val kSerializer = Float.serializer().mapped("simpleFloat", ::SimpleFloat, SimpleFloat::data)
     }
 }
 
 data class SimpleDouble(val data: Double) : SimpleInterface {
     companion object {
-        val kSerializer = DoubleSerializer.mapped("simpleDouble", ::SimpleDouble, SimpleDouble::data)
+        val kSerializer = Double.serializer().mapped("simpleDouble", ::SimpleDouble, SimpleDouble::data)
     }
 }
 
 data class SimpleChar(val data: Char) : SimpleInterface {
     companion object {
-        val kSerializer = CharSerializer.mapped("simpleChar", ::SimpleChar, SimpleChar::data)
+        val kSerializer = Char.serializer().mapped("simpleChar", ::SimpleChar, SimpleChar::data)
     }
 }
 
 data class SimpleString(val data: String) : SimpleInterface {
     companion object {
-        val kSerializer = StringSerializer.mapped("simpleString", ::SimpleString, SimpleString::data)
+        val kSerializer = String.serializer().mapped("simpleString", ::SimpleString, SimpleString::data)
     }
 }
 
@@ -131,17 +123,17 @@ enum class SimpleEnum : SimpleInterface {
 
 fun SerialDescriptor.withName(newName: String): SerialDescriptor {
     return object : SerialDescriptor by this {
-        override val name: String = newName
+        override val serialName: String = newName
     }
 }
 
-inline fun <S, T> KSerializer<S>.mapped(descriptorName: String = descriptor.name, crossinline fromSource: (S) -> T, crossinline toSource: (T) -> S): KSerializer<T> {
+inline fun <S, T> KSerializer<S>.mapped(descriptorName: String = descriptor.serialName, crossinline fromSource: (S) -> T, crossinline toSource: (T) -> S): KSerializer<T> {
     return object : KSerializer<T> {
         override val descriptor: SerialDescriptor = this@mapped.descriptor.withName(descriptorName)
 
         override fun deserialize(decoder: Decoder): T = fromSource(this@mapped.deserialize(decoder))
 
-        override fun serialize(encoder: Encoder, obj: T) = this@mapped.serialize(encoder, toSource(obj))
+        override fun serialize(encoder: Encoder, value: T) = this@mapped.serialize(encoder, toSource(value))
     }
 }
 


### PR DESCRIPTION
 - Use {type}.serializer() method instead of {type}Serializer class
 - Use list and nullable extension property in builtin package
 - Use MapSerializer class instead of map extension property
 - Use object to serialize kotlin.Unit
 - Use AbstractEncoder/Decoder instead of ElementValueEncoder/Decoder
 - Implement decodeElementIndex in AbstractDecoder
 - Change parameter name of implemented method to match with super method
