### PR TITLE
Add support for different flow styles in Sequences

### DIFF
--- a/src/main/kotlin/com/charleskorn/kaml/YamlConfiguration.kt
+++ b/src/main/kotlin/com/charleskorn/kaml/YamlConfiguration.kt
@@ -31,6 +31,7 @@ import org.snakeyaml.engine.v2.common.FlowStyle
  *    * [PolymorphismStyle.Property]: use a property (eg. `{ type: typeOfThing, property: value }`)
  * * [encodingIndentationSize]: number of spaces to use as indentation when encoding objects as YAML
  * * [breakScalarsAt]: maximum length of scalars when encoding objects as YAML (scalars exceeding this length will be split into multiple lines)
+ * * [sequenceStyle]: how sequences (aka lists and arrays) should be formatted. See [SequenceStyle] for an example of each
  */
 public data class YamlConfiguration constructor(
     internal val encodeDefaults: Boolean = true,
@@ -48,6 +49,21 @@ public enum class PolymorphismStyle {
 }
 
 public enum class SequenceStyle(internal val flowStyle: FlowStyle) {
+    /**
+     * The block form, eg
+     * ```yaml
+     * - 1
+     * - 2
+     * - 3
+     * ```
+     */
     Block(FlowStyle.BLOCK),
+
+    /**
+     * The flow form, eg
+     * ```yaml
+     * [1, 2, 3]
+     * ```
+     */
     Flow(FlowStyle.FLOW)
 }

--- a/src/main/kotlin/com/charleskorn/kaml/YamlConfiguration.kt
+++ b/src/main/kotlin/com/charleskorn/kaml/YamlConfiguration.kt
@@ -18,6 +18,8 @@
 
 package com.charleskorn.kaml
 
+import org.snakeyaml.engine.v2.common.FlowStyle
+
 /**
  * Configuration options for parsing YAML to objects and serialising objects to YAML.
  *
@@ -36,10 +38,16 @@ public data class YamlConfiguration constructor(
     internal val extensionDefinitionPrefix: String? = null,
     internal val polymorphismStyle: PolymorphismStyle = PolymorphismStyle.Tag,
     internal val encodingIndentationSize: Int = 2,
-    internal val breakScalarsAt: Int = 80
+    internal val breakScalarsAt: Int = 80,
+    internal val sequenceStyle: SequenceStyle = SequenceStyle.Block
 )
 
 public enum class PolymorphismStyle {
     Tag,
     Property
+}
+
+public enum class SequenceStyle(internal val flowStyle: FlowStyle) {
+    Block(FlowStyle.BLOCK),
+    Flow(FlowStyle.FLOW)
 }

--- a/src/main/kotlin/com/charleskorn/kaml/YamlOutput.kt
+++ b/src/main/kotlin/com/charleskorn/kaml/YamlOutput.kt
@@ -95,7 +95,7 @@ internal class YamlOutput(
     override fun beginStructure(descriptor: SerialDescriptor): CompositeEncoder {
         when (descriptor.kind) {
             is PolymorphicKind -> shouldReadTypeName = true
-            StructureKind.LIST -> emitter.emit(SequenceStartEvent(Optional.empty(), Optional.empty(), true, FlowStyle.BLOCK))
+            StructureKind.LIST -> emitter.emit(SequenceStartEvent(Optional.empty(), Optional.empty(), true, configuration.sequenceStyle.flowStyle))
             StructureKind.MAP, StructureKind.CLASS, StructureKind.OBJECT -> {
                 val typeName = getAndClearTypeName()
 

--- a/src/test/kotlin/com/charleskorn/kaml/YamlWritingTest.kt
+++ b/src/test/kotlin/com/charleskorn/kaml/YamlWritingTest.kt
@@ -22,7 +22,17 @@ import ch.tutteli.atrium.api.fluent.en_GB.message
 import ch.tutteli.atrium.api.fluent.en_GB.toBe
 import ch.tutteli.atrium.api.fluent.en_GB.toThrow
 import ch.tutteli.atrium.api.verbs.expect
-import com.charleskorn.kaml.testobjects.*
+import com.charleskorn.kaml.testobjects.NestedObjects
+import com.charleskorn.kaml.testobjects.SealedWrapper
+import com.charleskorn.kaml.testobjects.SimpleStructure
+import com.charleskorn.kaml.testobjects.Team
+import com.charleskorn.kaml.testobjects.TestEnum
+import com.charleskorn.kaml.testobjects.TestSealedStructure
+import com.charleskorn.kaml.testobjects.UnsealedClass
+import com.charleskorn.kaml.testobjects.UnsealedString
+import com.charleskorn.kaml.testobjects.UnwrappedInterface
+import com.charleskorn.kaml.testobjects.UnwrappedString
+import com.charleskorn.kaml.testobjects.polymorphicModule
 import kotlinx.serialization.PolymorphicSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.ListSerializer
@@ -183,18 +193,13 @@ object YamlWritingTest : Spek({
             }
 
             context("serializing a string longer than the maximum scalar width") {
-                val output = Yaml(configuration = YamlConfiguration(breakScalarsAt = 80)).encodeToString(
-                    String.serializer(),
-                    "Hello world this is a string that is much, much, much (ok, not that much) longer than 80 characters"
-                )
+                val output = Yaml(configuration = YamlConfiguration(breakScalarsAt = 80)).encodeToString(String.serializer(), "Hello world this is a string that is much, much, much (ok, not that much) longer than 80 characters")
 
                 it("returns the value serialized in the expected YAML form, broken onto a new line at the maximum scalar width") {
-                    expect(output).toBe(
-                        """
+                    expect(output).toBe("""
                         |"Hello world this is a string that is much, much, much (ok, not that much) longer\
                         |  \ than 80 characters"
-                    """.trimMargin()
-                    )
+                    """.trimMargin())
                 }
             }
         }

--- a/src/test/kotlin/com/charleskorn/kaml/YamlWritingTest.kt
+++ b/src/test/kotlin/com/charleskorn/kaml/YamlWritingTest.kt
@@ -288,39 +288,23 @@ object YamlWritingTest : Spek({
 
             context("serializing a list of strings with a string longer than the maximum scalar width") {
                 val yamlWithScalarLimit = Yaml(configuration = YamlConfiguration(breakScalarsAt = 80))
-                val output = yamlWithScalarLimit.encodeToString(
-                    ListSerializer(String.serializer()),
-                    listOf(
-                        "item1",
-                        "Hello world this is a string that is much, much, much (ok, not that much) longer than 80 characters"
-                    )
-                )
+                val output = yamlWithScalarLimit.encodeToString(ListSerializer(String.serializer()), listOf("item1", "Hello world this is a string that is much, much, much (ok, not that much) longer than 80 characters"))
 
                 it("returns the value serialized in the expected YAML form, broken onto a new line at the maximum scalar width") {
-                    expect(output).toBe(
-                        """
+                    expect(output).toBe("""
                         |- "item1"
                         |- "Hello world this is a string that is much, much, much (ok, not that much) longer\
                         |  \ than 80 characters"
-                    """.trimMargin()
-                    )
+                    """.trimMargin())
                 }
             }
 
             context("serializing a list of strings with a string longer than the maximum scalar width in flow form") {
-                val yamlWithScalarLimit =
-                    Yaml(configuration = YamlConfiguration(breakScalarsAt = 80, sequenceStyle = SequenceStyle.Flow))
-                val output = yamlWithScalarLimit.encodeToString(
-                    ListSerializer(String.serializer()),
-                    listOf(
-                        "item1",
-                        "Hello world this is a string that is much, much, much (ok, not that much) longer than 80 characters"
-                    )
-                )
+                val yamlWithScalarLimit = Yaml(configuration = YamlConfiguration(breakScalarsAt = 80, sequenceStyle = SequenceStyle.Flow))
+                val output = yamlWithScalarLimit.encodeToString(ListSerializer(String.serializer()), listOf("item1", "Hello world this is a string that is much, much, much (ok, not that much) longer than 80 characters"))
 
                 it("returns the value serialized in the expected YAML form, broken onto a new line at the maximum scalar width") {
-                    expect(output).toBe(
-                        """
+                    expect(output).toBe("""
                     ["item1", "Hello world this is a string that is much, much, much (ok, not that much)\
                         \ longer than 80 characters"]
                     """.trimIndent()
@@ -390,29 +374,7 @@ object YamlWritingTest : Spek({
                 }
             }
 
-            context("serializing a list of maps from strings to strings in flow form") {
-                val input = listOf(
-                    mapOf(
-                        "key1" to "value1",
-                        "key2" to "value2"
-                    ),
-                    mapOf(
-                        "key3" to "value3"
-                    )
-                )
-
-                val serializer = ListSerializer(MapSerializer(String.serializer(), String.serializer()))
-                val output = Yaml(configuration = YamlConfiguration(sequenceStyle = SequenceStyle.Flow))
-                    .encodeToString(serializer, input)
-
-                it("returns the value serialized in the expected YAML form") {
-                    expect(output).toBe(
-                        """[{"key1": "value1", "key2": "value2"}, {"key3": "value3"}]"""
-                    )
-                }
-            }
-
-            context("serializing a list of objects in flow form") {
+            context("serializing a list of objects") {
                 val input = listOf(
                     SimpleStructure("name1"),
                     SimpleStructure("name2")
@@ -435,8 +397,7 @@ object YamlWritingTest : Spek({
                     SimpleStructure("name2")
                 )
 
-                val output = Yaml(configuration = YamlConfiguration(sequenceStyle = SequenceStyle.Flow))
-                    .encodeToString(ListSerializer(SimpleStructure.serializer()), input)
+                val output = Yaml(configuration = YamlConfiguration(sequenceStyle = SequenceStyle.Flow)).encodeToString(ListSerializer(SimpleStructure.serializer()), input)
 
                 it("returns the value serialized in the expected YAML form") {
                     expect(output).toBe(
@@ -478,8 +439,7 @@ object YamlWritingTest : Spek({
                     )
                 )
 
-                val serializer =
-                    MapSerializer(String.serializer(), MapSerializer(String.serializer(), String.serializer()))
+                val serializer = MapSerializer(String.serializer(), MapSerializer(String.serializer(), String.serializer()))
                 val output = Yaml.default.encodeToString(serializer, input)
 
                 it("returns the value serialized in the expected YAML form") {
@@ -652,10 +612,7 @@ object YamlWritingTest : Spek({
 
         describe("serializing polymorphic values") {
             describe("given tags are used to store the type information") {
-                val polymorphicYaml = Yaml(
-                    serializersModule = polymorphicModule,
-                    configuration = YamlConfiguration(polymorphismStyle = PolymorphismStyle.Tag)
-                )
+                val polymorphicYaml = Yaml(serializersModule = polymorphicModule, configuration = YamlConfiguration(polymorphismStyle = PolymorphismStyle.Tag))
 
                 describe("serializing a sealed type") {
                     val input = TestSealedStructure.SimpleSealedInt(5)
@@ -717,8 +674,7 @@ object YamlWritingTest : Spek({
                         null
                     )
 
-                    val output =
-                        polymorphicYaml.encodeToString(ListSerializer(TestSealedStructure.serializer().nullable), input)
+                    val output = polymorphicYaml.encodeToString(ListSerializer(TestSealedStructure.serializer().nullable), input)
 
                     val expectedYaml = """
                         - !<sealedInt>
@@ -739,10 +695,7 @@ object YamlWritingTest : Spek({
             }
 
             describe("given properties are used to store the type information") {
-                val polymorphicYaml = Yaml(
-                    serializersModule = polymorphicModule,
-                    configuration = YamlConfiguration(polymorphismStyle = PolymorphismStyle.Property)
-                )
+                val polymorphicYaml = Yaml(serializersModule = polymorphicModule, configuration = YamlConfiguration(polymorphismStyle = PolymorphismStyle.Property))
 
                 describe("serializing a sealed type") {
                     val input = TestSealedStructure.SimpleSealedInt(5)
@@ -774,12 +727,7 @@ object YamlWritingTest : Spek({
                     val input = UnwrappedString("blah")
 
                     it("throws an appropriate exception") {
-                        expect {
-                            polymorphicYaml.encodeToString(
-                                PolymorphicSerializer(UnwrappedInterface::class),
-                                input
-                            )
-                        }.toThrow<IllegalStateException> {
+                        expect({ polymorphicYaml.encodeToString(PolymorphicSerializer(UnwrappedInterface::class), input) }).toThrow<IllegalStateException> {
                             message { toBe("Cannot serialize a polymorphic value that is not a YAML object when using PolymorphismStyle.Property.") }
                         }
                     }
@@ -808,8 +756,7 @@ object YamlWritingTest : Spek({
                         null
                     )
 
-                    val output =
-                        polymorphicYaml.encodeToString(ListSerializer(TestSealedStructure.serializer().nullable), input)
+                    val output = polymorphicYaml.encodeToString(ListSerializer(TestSealedStructure.serializer().nullable), input)
 
                     val expectedYaml = """
                         - type: "sealedInt"
@@ -838,12 +785,7 @@ object YamlWritingTest : Spek({
                     val input = SimpleStructure("name1")
 
                     it("is always written") {
-                        expect(
-                            defaultEncoder.encodeToString(
-                                SimpleStructure.serializer(),
-                                input
-                            )
-                        ).toBe("""name: "name1"""")
+                        expect(defaultEncoder.encodeToString(SimpleStructure.serializer(), input)).toBe("""name: "name1"""")
                     }
                 }
 
@@ -851,12 +793,7 @@ object YamlWritingTest : Spek({
                     val input = SimpleStructureWithDefault()
 
                     it("is written") {
-                        expect(
-                            defaultEncoder.encodeToString(
-                                SimpleStructureWithDefault.serializer(),
-                                input
-                            )
-                        ).toBe("""name: "default"""")
+                        expect(defaultEncoder.encodeToString(SimpleStructureWithDefault.serializer(), input)).toBe("""name: "default"""")
                     }
                 }
 
@@ -864,12 +801,7 @@ object YamlWritingTest : Spek({
                     val input = SimpleStructureWithDefault("name1")
 
                     it("is written") {
-                        expect(
-                            defaultEncoder.encodeToString(
-                                SimpleStructureWithDefault.serializer(),
-                                input
-                            )
-                        ).toBe("""name: "name1"""")
+                        expect(defaultEncoder.encodeToString(SimpleStructureWithDefault.serializer(), input)).toBe("""name: "name1"""")
                     }
                 }
             }
@@ -881,12 +813,7 @@ object YamlWritingTest : Spek({
                     val input = SimpleStructure("name1")
 
                     it("is always written") {
-                        expect(
-                            noDefaultEncoder.encodeToString(
-                                SimpleStructure.serializer(),
-                                input
-                            )
-                        ).toBe("""name: "name1"""")
+                        expect(noDefaultEncoder.encodeToString(SimpleStructure.serializer(), input)).toBe("""name: "name1"""")
                     }
                 }
 
@@ -894,12 +821,7 @@ object YamlWritingTest : Spek({
                     val input = SimpleStructureWithDefault()
 
                     it("is not written") {
-                        expect(
-                            noDefaultEncoder.encodeToString(
-                                SimpleStructureWithDefault.serializer(),
-                                input
-                            )
-                        ).toBe("""{}""")
+                        expect(noDefaultEncoder.encodeToString(SimpleStructureWithDefault.serializer(), input)).toBe("""{}""")
                     }
                 }
 
@@ -907,12 +829,7 @@ object YamlWritingTest : Spek({
                     val input = SimpleStructureWithDefault("name1")
 
                     it("is written") {
-                        expect(
-                            noDefaultEncoder.encodeToString(
-                                SimpleStructureWithDefault.serializer(),
-                                input
-                            )
-                        ).toBe("""name: "name1"""")
+                        expect(noDefaultEncoder.encodeToString(SimpleStructureWithDefault.serializer(), input)).toBe("""name: "name1"""")
                     }
                 }
             }


### PR DESCRIPTION
This adds support for the Flow Style of rendering Sequences, by adding a parameter to `YamlConfiguration`

The default block style is still used to avoid breaking anything.

This is referenced in #33 