### PR TITLE
Support custom polymorphic key

### DIFF
--- a/src/main/kotlin/com/charleskorn/kaml/YamlConfiguration.kt
+++ b/src/main/kotlin/com/charleskorn/kaml/YamlConfiguration.kt
@@ -38,6 +38,7 @@ public data class YamlConfiguration constructor(
     internal val strictMode: Boolean = true,
     internal val extensionDefinitionPrefix: String? = null,
     internal val polymorphismStyle: PolymorphismStyle = PolymorphismStyle.Tag,
+    internal val polymorphismPropertyName: String = "type",
     internal val encodingIndentationSize: Int = 2,
     internal val breakScalarsAt: Int = 80,
     internal val sequenceStyle: SequenceStyle = SequenceStyle.Block

--- a/src/main/kotlin/com/charleskorn/kaml/YamlConfiguration.kt
+++ b/src/main/kotlin/com/charleskorn/kaml/YamlConfiguration.kt
@@ -29,6 +29,7 @@ import org.snakeyaml.engine.v2.common.FlowStyle
  * * [polymorphismStyle]: how to read or write the type of a polymorphic object:
  *    * [PolymorphismStyle.Tag]: use a YAML tag (eg. `!<typeOfThing> { property: value }`)
  *    * [PolymorphismStyle.Property]: use a property (eg. `{ type: typeOfThing, property: value }`)
+ * * [polymorphismPropertyName]: property name to use when [polymorphismStyle] is [PolymorphismStyle.Property]
  * * [encodingIndentationSize]: number of spaces to use as indentation when encoding objects as YAML
  * * [breakScalarsAt]: maximum length of scalars when encoding objects as YAML (scalars exceeding this length will be split into multiple lines)
  * * [sequenceStyle]: how sequences (aka lists and arrays) should be formatted. See [SequenceStyle] for an example of each

--- a/src/main/kotlin/com/charleskorn/kaml/YamlInput.kt
+++ b/src/main/kotlin/com/charleskorn/kaml/YamlInput.kt
@@ -82,13 +82,14 @@ public sealed class YamlInput(
         }
 
         private fun createPolymorphicMapDeserializer(node: YamlMap, context: SerializersModule, configuration: YamlConfiguration): YamlPolymorphicInput {
-            when (val typeName = node.getValue("type")) {
-                is YamlList -> throw InvalidPropertyValueException("type", "expected a string, but got a list", typeName.location)
-                is YamlMap -> throw InvalidPropertyValueException("type", "expected a string, but got a map", typeName.location)
-                is YamlNull -> throw InvalidPropertyValueException("type", "expected a string, but got a null value", typeName.location)
-                is YamlTaggedNode -> throw InvalidPropertyValueException("type", "expected a string, but got a tagged value", typeName.location)
+            val desiredKey = configuration.polymorphismPropertyName
+            when (val typeName = node.getValue(desiredKey)) {
+                is YamlList -> throw InvalidPropertyValueException(desiredKey, "expected a string, but got a list", typeName.location)
+                is YamlMap -> throw InvalidPropertyValueException(desiredKey, "expected a string, but got a map", typeName.location)
+                is YamlNull -> throw InvalidPropertyValueException(desiredKey, "expected a string, but got a null value", typeName.location)
+                is YamlTaggedNode -> throw InvalidPropertyValueException(desiredKey, "expected a string, but got a tagged value", typeName.location)
                 is YamlScalar -> {
-                    val remainingProperties = node.withoutKey("type")
+                    val remainingProperties = node.withoutKey(desiredKey)
 
                     return YamlPolymorphicInput(typeName.content, remainingProperties, context, configuration)
                 }

--- a/src/main/kotlin/com/charleskorn/kaml/YamlOutput.kt
+++ b/src/main/kotlin/com/charleskorn/kaml/YamlOutput.kt
@@ -108,7 +108,7 @@ internal class YamlOutput(
                         emitter.emit(MappingStartEvent(Optional.empty(), Optional.empty(), true, FlowStyle.BLOCK))
 
                         if (typeName.isPresent) {
-                            emitPlainScalar("type")
+                            emitPlainScalar(configuration.polymorphismPropertyName)
                             emitQuotedScalar(typeName.get())
                         }
                     }


### PR DESCRIPTION
I'm sorry for the sudden PR.


For personal reasons, I created a polymorphic key that can be changed to something other than "type", such as the `classDiscriminator` option in` kotlinx.serialization.json.Json`.

If this proposal is accepted, I would be grateful if you could incorporate it into the main branch.
