### PR TITLE
More elegant way to call the library's API

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ val input = """
     """.trimIndent()
 
 val result = Yaml.default.decodeFromString(Team.serializer(), input)
+// or using more elegant way:
+// val result = Yaml.decodeFromString<Team>(input)
 
 println(result)
 ```
@@ -47,6 +49,8 @@ data class Team(
 val input = Team("Amy", listOf("Bob", "Cindy", "Dan"))
 
 val result = Yaml.default.encodeToString(Team.serializer(), input)
+// or using more elegant way:
+// val result = Yaml.encodeToString<Team>(input)
 
 println(result)
 ```

--- a/src/main/kotlin/com/charleskorn/kaml/Yaml.kt
+++ b/src/main/kotlin/com/charleskorn/kaml/Yaml.kt
@@ -20,10 +20,12 @@ package com.charleskorn.kaml
 
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.SerializationStrategy
 import kotlinx.serialization.StringFormat
 import kotlinx.serialization.modules.EmptySerializersModule
 import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.serializer
 import org.snakeyaml.engine.v2.api.StreamDataWriter
 import java.io.StringWriter
 
@@ -55,5 +57,15 @@ public class Yaml(
 
     public companion object {
         public val default: Yaml = Yaml()
+
+        // using these wrappers you can easily and in more elegant way to call the encoder/decoder directly with a type:
+        // Yaml.decodeFromString<Team>(input) or Yaml.encodeToString<Team>(input)
+        @OptIn(InternalSerializationApi::class)
+        public inline fun <reified T : Any> decodeFromString(string: String): T =
+            Yaml().decodeFromString(T::class.serializer(), string)
+
+        @OptIn(InternalSerializationApi::class)
+        public inline fun <reified T : Any> encodeToString(value: T): String =
+            Yaml().encodeToString(T::class.serializer(), value)
     }
 }

--- a/src/test/kotlin/com/charleskorn/kaml/YamlWrapperTest.kt
+++ b/src/test/kotlin/com/charleskorn/kaml/YamlWrapperTest.kt
@@ -1,0 +1,124 @@
+/*
+
+   Copyright 2018-2020 Charles Korn.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+*/
+
+@file:OptIn(InternalSerializationApi::class, ExperimentalSerializationApi::class)
+
+package com.charleskorn.kaml.testobjects
+
+import ch.tutteli.atrium.api.fluent.en_GB.toBe
+import ch.tutteli.atrium.api.verbs.expect
+import com.charleskorn.kaml.Yaml
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.serializer
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+object YamlReadingTest : Spek({
+    describe("a YAML parser") {
+        describe("parsing scalars") {
+            context("given the input 'hello'") {
+                val input = "hello"
+
+                context("parsing that input as a string") {
+                    val result = Yaml.decodeFromString<String>(input)
+
+                    it("deserializes it to the expected string value") {
+                        expect(result).toBe("hello")
+                    }
+                }
+            }
+
+            context("given the input '123'") {
+                val input = "123"
+
+                context("parsing that input as an integer") {
+                    val result = Yaml.default.decodeFromString(Int.serializer(), input)
+
+                    it("deserializes it to the expected integer") {
+                        expect(result).toBe(123)
+                    }
+                }
+
+                context("parsing that input as a long") {
+                    val result = Yaml.default.decodeFromString(Long.serializer(), input)
+
+                    it("deserializes it to the expected long") {
+                        expect(result).toBe(123)
+                    }
+                }
+            }
+        }
+
+        describe("parsing objects") {
+            context("given some input representing an object with an optional value specified") {
+                val input = """
+                    string: Alex
+                    byte: 12
+                    short: 1234
+                    int: 123456
+                    long: 1234567
+                    float: 1.2
+                    double: 2.4
+                    enum: Value1
+                    boolean: true
+                    char: A
+                    nullable: present
+                """.trimIndent()
+
+                context("parsing that input") {
+                    val result = Yaml.decodeFromString<ComplexStructure>(input)
+
+                    it("deserializes it to a Kotlin object") {
+                        expect(result).toBe(
+                            ComplexStructure(
+                                "Alex",
+                                12,
+                                1234,
+                                123456,
+                                1234567,
+                                1.2f,
+                                2.4,
+                                TestEnum.Value1,
+                                true,
+                                'A',
+                                "present"
+                            )
+                        )
+                    }
+                }
+            }
+        }
+    }
+}) {
+    @Serializable
+    private data class ComplexStructure(
+        val string: String,
+        val byte: Byte,
+        val short: Short,
+        val int: Int,
+        val long: Long,
+        val float: Float,
+        val double: Double,
+        val enum: TestEnum,
+        val boolean: Boolean,
+        val char: Char,
+        val nullable: String? = null
+    )
+}


### PR DESCRIPTION
### What's done:
1) Added wrappers to call kaml in more elegant way
2) Added tests and documentation