### PR TITLE
Make faster duplicate keys checking

### DIFF
--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlNode.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlNode.kt
@@ -154,12 +154,15 @@ public data class YamlMap(val entries: Map<YamlScalar, YamlNode>, override val p
             }
         }
 
-        keys.forEachIndexed { index, key ->
-            val duplicate = keys.subList(0, index).firstOrNull { it.equivalentContentTo(key) }
+        val encounteredKeys = mutableMapOf<String, YamlScalar>()
+        keys.forEach { key ->
+            val duplicate = encounteredKeys[key.content]
 
             if (duplicate != null) {
                 throw DuplicateKeyException(duplicate.path, key.path, key.contentToString())
             }
+
+            encounteredKeys[key.content] = key
         }
     }
 


### PR DESCRIPTION
My use case involves a big file with a top level map with a bit over 40 thousand keys. Parsing it took two minutes on my laptop. After my changes parsing time went down to 10 seconds.