### PR TITLE
Detect and report all duplicated keys

### DIFF
--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlInput.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlInput.kt
@@ -267,7 +267,7 @@ private sealed class YamlMapLikeInputBase(map: YamlMap, context: SerializersModu
     protected fun <T> fromCurrentValue(action: YamlInput.() -> T): T {
         try {
             return action(currentValueDecoder)
-        } catch (e: YamlException) {
+        } catch (e: SinglePathYamlException) {
             if (currentlyReadingValue) {
                 throw InvalidPropertyValueException(propertyName, e.message, e.path, e)
             } else {

--- a/src/commonTest/kotlin/com/charleskorn/kaml/Assertions.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/Assertions.kt
@@ -22,36 +22,20 @@ import ch.tutteli.atrium.api.fluent.en_GB.feature
 import ch.tutteli.atrium.creating.Expect
 import kotlin.jvm.JvmName
 
-fun <T : YamlException> Expect<T>.path(assertionCreator: Expect<YamlPath>.() -> Unit) {
-    feature(YamlException::path).addAssertionsCreatedBy(assertionCreator)
+fun <T : SinglePathYamlException> Expect<T>.path(assertionCreator: Expect<YamlPath>.() -> Unit) {
+    feature(SinglePathYamlException::path).addAssertionsCreatedBy(assertionCreator)
 }
 
-fun <T : YamlException> Expect<T>.line(assertionCreator: Expect<Int>.() -> Unit) {
-    feature(YamlException::line).addAssertionsCreatedBy(assertionCreator)
+fun <T : SinglePathYamlException> Expect<T>.line(assertionCreator: Expect<Int>.() -> Unit) {
+    feature(SinglePathYamlException::line).addAssertionsCreatedBy(assertionCreator)
 }
 
-fun <T : YamlException> Expect<T>.column(assertionCreator: Expect<Int>.() -> Unit) {
-    feature(YamlException::column).addAssertionsCreatedBy(assertionCreator)
+fun <T : SinglePathYamlException> Expect<T>.column(assertionCreator: Expect<Int>.() -> Unit) {
+    feature(SinglePathYamlException::column).addAssertionsCreatedBy(assertionCreator)
 }
 
-fun Expect<DuplicateKeyException>.originalLocation(assertionCreator: Expect<Location>.() -> Unit) {
-    feature(DuplicateKeyException::originalLocation).addAssertionsCreatedBy(assertionCreator)
-}
-
-fun Expect<DuplicateKeyException>.duplicateLocation(assertionCreator: Expect<Location>.() -> Unit) {
-    feature(DuplicateKeyException::duplicateLocation).addAssertionsCreatedBy(assertionCreator)
-}
-
-fun Expect<DuplicateKeyException>.originalPath(assertionCreator: Expect<YamlPath>.() -> Unit) {
-    feature(DuplicateKeyException::originalPath).addAssertionsCreatedBy(assertionCreator)
-}
-
-fun Expect<DuplicateKeyException>.duplicatePath(assertionCreator: Expect<YamlPath>.() -> Unit) {
-    feature(DuplicateKeyException::duplicatePath).addAssertionsCreatedBy(assertionCreator)
-}
-
-fun Expect<DuplicateKeyException>.key(assertionCreator: Expect<String>.() -> Unit) {
-    feature(DuplicateKeyException::key).addAssertionsCreatedBy(assertionCreator)
+fun Expect<DuplicateKeysException>.duplicates(assertionCreator: Expect<Map<YamlPath, List<YamlPath>>>.() -> Unit) {
+    feature(DuplicateKeysException::duplicates).addAssertionsCreatedBy(assertionCreator)
 }
 
 @JvmName("MissingRequiredPropertyExceptionPropertyName")

--- a/src/commonTest/kotlin/com/charleskorn/kaml/SinglePathYamlExceptionTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/SinglePathYamlExceptionTest.kt
@@ -23,14 +23,14 @@ import ch.tutteli.atrium.api.verbs.expect
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
-object YamlExceptionTest : Spek({
+object SinglePathYamlExceptionTest : Spek({
     describe("a YAML exception") {
         describe("formatting it as a string") {
             val path = YamlPath.root.withMapElementKey("colours", Location(3, 4)).withMapElementValue(Location(4, 1)).withListEntry(2, Location(123, 456))
-            val exception = YamlException("Something went wrong", path)
+            val exception = SinglePathYamlException("Something went wrong", path)
 
             it("includes the class name, location information and message") {
-                expect(exception.toString()).toBe("com.charleskorn.kaml.YamlException at colours[2] on line 123, column 456: Something went wrong")
+                expect(exception.toString()).toBe("com.charleskorn.kaml.SinglePathYamlException at colours[2] on line 123, column 456: Something went wrong")
             }
         }
     }

--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlReadingDuplicatesTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlReadingDuplicatesTest.kt
@@ -1,0 +1,198 @@
+package com.charleskorn.kaml
+
+import ch.tutteli.atrium.api.fluent.en_GB.message
+import ch.tutteli.atrium.api.fluent.en_GB.notToThrow
+import ch.tutteli.atrium.api.fluent.en_GB.toBe
+import ch.tutteli.atrium.api.fluent.en_GB.toThrow
+import ch.tutteli.atrium.api.verbs.expect
+import kotlinx.serialization.decodeFromString
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class YamlReadingDuplicatesTest : Spek({
+    describe("reading YAML objects") {
+        val parser = Yaml.default
+
+        context("without duplicates") {
+            val yaml = """
+                key1: {}
+                key2: {}
+            """.trimIndent()
+
+            it("does not throw exceptions") {
+                expect({ parser.decodeFromString<MapStructure>(yaml) }).notToThrow()
+            }
+        }
+
+        context("with a single duplicate of a single key") {
+            val yaml = """
+                key1: {}
+                key1: {}
+            """.trimIndent()
+
+            it("throws an exception with a correct message") {
+                expect({ parser.decodeFromString<MapStructure>(yaml) }).toThrow<DuplicateKeysException> {
+                    message.toBe(
+                        """
+                            Found duplicates of key 'key1' defined at line 1, column 1:
+                              - line 2, column 1
+                        """.trimIndent()
+                    )
+                }
+            }
+        }
+
+        context("with multiple duplicates of a single key") {
+            val yaml = """
+                key1: {}
+                key1: {}
+                key2: {}
+                key1: {}
+            """.trimIndent()
+
+            it("throws an exception with a correct message") {
+                expect({ parser.decodeFromString<MapStructure>(yaml) }).toThrow<DuplicateKeysException> {
+                    message.toBe(
+                        """
+                            Found duplicates of key 'key1' defined at line 1, column 1:
+                              - line 2, column 1
+                              - line 4, column 1
+                        """.trimIndent()
+                    )
+                }
+            }
+        }
+
+        context("with multiple duplicates of a multiple keys") {
+            val yaml = """
+                key1: {}
+                key2: {}
+                key3: {}
+                key1: {}
+                key2: {}
+                key3: {}
+                key2: {}
+                key3: {}
+                key1: {}
+                key3: {}
+            """.trimIndent()
+
+            it("throws an exception with a correct message") {
+                expect({ parser.decodeFromString<MapStructure>(yaml) }).toThrow<DuplicateKeysException> {
+                    message.toBe(
+                        """
+                            Found duplicates of key 'key1' defined at line 1, column 1:
+                              - line 4, column 1
+                              - line 9, column 1
+                            Found duplicates of key 'key2' defined at line 2, column 1:
+                              - line 5, column 1
+                              - line 7, column 1
+                            Found duplicates of key 'key3' defined at line 3, column 1:
+                              - line 6, column 1
+                              - line 8, column 1
+                              - line 10, column 1
+                        """.trimIndent()
+                    )
+                }
+            }
+        }
+
+        context("with duplicates in nested values") {
+            val yaml = """
+                key1:
+                  key1: {}
+                  key1: {}
+                key2:
+                  key1: {}
+                  key1: {}
+            """.trimIndent()
+
+            it("throws an exception with a correct message") {
+                expect({ parser.decodeFromString<MapStructure>(yaml) }).toThrow<DuplicateKeysException> {
+                    message.toBe(
+                        """
+                            Found duplicates of key 'key1.key1' defined at line 2, column 3:
+                              - line 3, column 3
+                            Found duplicates of key 'key2.key1' defined at line 5, column 3:
+                              - line 6, column 3
+                        """.trimIndent()
+                    )
+                }
+            }
+        }
+
+        context("with duplicates of keys with the same structures") {
+            val yaml = """
+                key1:
+                  key1: {}
+                  key2: {}
+                key1:
+                  key1: {}
+                  key2: {}
+            """.trimIndent()
+
+            it("throws an exception without detecting duplicates between nested structures") {
+                expect({ parser.decodeFromString<MapStructure>(yaml) }).toThrow<DuplicateKeysException> {
+                    message.toBe(
+                        """
+                            Found duplicates of key 'key1' defined at line 1, column 1:
+                              - line 4, column 1
+                        """.trimIndent()
+                    )
+                }
+            }
+        }
+
+        context("with duplicates in complex structures") {
+            val yaml = """
+                 key1:
+                   key1:
+                     key1: value
+                     key2: value
+                   key1: {}
+                   key2:
+                     key1: value
+                     key1: value
+                     key1: value
+                   key2:
+                     key1: value
+                     key1: value
+                   key3: {}
+                 key1: {}
+                 key2:
+                   key1:
+                     key1: value
+                     key2: value
+                   key2: {}
+                   key3:
+                     key1: value
+                     key2: value
+                     key1: value
+            """.trimIndent()
+
+            it("throws an exception without detecting duplicates between nested structures") {
+                expect({ parser.decodeFromString<MapStructure>(yaml) }).toThrow<DuplicateKeysException> {
+                    message.toBe(
+                        """
+                            Found duplicates of key 'key1' defined at line 1, column 1:
+                              - line 14, column 1
+                            Found duplicates of key 'key1.key1' defined at line 2, column 3:
+                              - line 5, column 3
+                            Found duplicates of key 'key1.key2' defined at line 6, column 3:
+                              - line 10, column 3
+                            Found duplicates of key 'key1.key2.key1' defined at line 7, column 5:
+                              - line 8, column 5
+                              - line 9, column 5
+                            Found duplicates of key 'key1.key2.key1' defined at line 11, column 5:
+                              - line 12, column 5
+                            Found duplicates of key 'key2.key3.key1' defined at line 21, column 5:
+                              - line 23, column 5
+                        """.trimIndent()
+                    )
+                }
+            }
+        }
+    }
+})
+
+private typealias MapStructure = Map<String, Map<String, Map<String, String>>>

--- a/src/jvmMain/kotlin/com/charleskorn/kaml/Yaml.kt
+++ b/src/jvmMain/kotlin/com/charleskorn/kaml/Yaml.kt
@@ -56,7 +56,7 @@ public actual class Yaml(
 
     override fun <T> encodeToString(serializer: SerializationStrategy<T>, value: T): String {
         val writer = object : StringWriter(), StreamDataWriter {
-            override fun flush() { }
+            override fun flush() {}
         }
 
         YamlOutput(writer, serializersModule, configuration).use { output ->

--- a/src/jvmMain/kotlin/com/charleskorn/kaml/Yaml.kt
+++ b/src/jvmMain/kotlin/com/charleskorn/kaml/Yaml.kt
@@ -56,7 +56,7 @@ public actual class Yaml(
 
     override fun <T> encodeToString(serializer: SerializationStrategy<T>, value: T): String {
         val writer = object : StringWriter(), StreamDataWriter {
-            override fun flush() {}
+            override fun flush() { }
         }
 
         YamlOutput(writer, serializersModule, configuration).use { output ->

--- a/src/jvmMain/kotlin/com/charleskorn/kaml/YamlNodeReader.kt
+++ b/src/jvmMain/kotlin/com/charleskorn/kaml/YamlNodeReader.kt
@@ -217,7 +217,8 @@ internal actual class YamlNodeReader(
                     duplicates.putAll(node.duplicates)
                     node.entries.values
                 }
-                is YamlScalar, is YamlNull, is YamlTaggedNode -> emptyList()
+                is YamlTaggedNode -> listOf(node.innerNode)
+                is YamlScalar, is YamlNull -> emptyList()
             }
         }
 


### PR DESCRIPTION
This is binary and source incompatible change as exceptions hierarchy and structure is changed. If library users rely on  path properties of `YamlException` they will not find them in that type anymore. I decided to change it this way to make sure that everyone still catches all exceptions as `DuplicateKeysException` does not extend previous `YamlException` (now `SinglePathYamlException`).

I created a separate test suite due to #27.

Closes #169