### PR TITLE
Add generic `decodeFromStream`/`encodeToStream` extension functions

### DIFF
--- a/src/jvmMain/kotlin/com/charleskorn/kaml/Yaml.kt
+++ b/src/jvmMain/kotlin/com/charleskorn/kaml/Yaml.kt
@@ -22,6 +22,7 @@ import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerializationStrategy
 import kotlinx.serialization.StringFormat
+import kotlinx.serialization.serializer
 import kotlinx.serialization.modules.EmptySerializersModule
 import kotlinx.serialization.modules.SerializersModule
 import org.snakeyaml.engine.v2.api.StreamDataWriter

--- a/src/jvmMain/kotlin/com/charleskorn/kaml/Yaml.kt
+++ b/src/jvmMain/kotlin/com/charleskorn/kaml/Yaml.kt
@@ -22,9 +22,9 @@ import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerializationStrategy
 import kotlinx.serialization.StringFormat
-import kotlinx.serialization.serializer
 import kotlinx.serialization.modules.EmptySerializersModule
 import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.serializer
 import org.snakeyaml.engine.v2.api.StreamDataWriter
 import org.snakeyaml.engine.v2.api.YamlOutputStreamWriter
 import java.io.IOException

--- a/src/jvmMain/kotlin/com/charleskorn/kaml/Yaml.kt
+++ b/src/jvmMain/kotlin/com/charleskorn/kaml/Yaml.kt
@@ -89,3 +89,20 @@ public actual class Yaml(
         public actual val default: Yaml = Yaml()
     }
 }
+
+/**
+ * Decodes and deserializes from the given [stream] to the value of type [T] using the
+ * deserializer retrieved from the reified type parameter.
+ */
+@OptIn(ExperimentalSerializationApi::class)
+public inline fun <reified T> Yaml.decodeFromStream(stream: InputStream): T =
+    decodeFromStream(serializersModule.serializer(), stream)
+
+/**
+ * Serializes and encodes the given [value] to the given [stream] using the serializer
+ * retrieved from the reified type parameter.
+ */
+@OptIn(ExperimentalSerializationApi::class)
+public inline fun <reified T> Yaml.encodeToStream(value: T, stream: OutputStream) {
+    encodeToStream(serializersModule.serializer(), value, stream)
+}

--- a/src/jvmTest/kotlin/com/charleskorn/kaml/JvmYamlReadingTest.kt
+++ b/src/jvmTest/kotlin/com/charleskorn/kaml/JvmYamlReadingTest.kt
@@ -35,5 +35,14 @@ object JvmYamlReadingTest : Spek({
                 expect(result).toEqual(123)
             }
         }
+
+        describe("parsing from a stream via generic extension function") {
+            val input = "123"
+            val result = Yaml.default.decodeFromStream<Int>(ByteArrayInputStream(input.toByteArray(Charsets.UTF_8)))
+
+            it("successfully deserializes values from a stream") {
+                expect(result).toEqual(123)
+            }
+        }
     }
 })

--- a/src/jvmTest/kotlin/com/charleskorn/kaml/JvmYamlWritingTest.kt
+++ b/src/jvmTest/kotlin/com/charleskorn/kaml/JvmYamlWritingTest.kt
@@ -35,5 +35,14 @@ object JvmYamlWritingTest : Spek({
                 expect(output.toString(Charsets.UTF_8)).toEqual("\"hello world\"\n")
             }
         }
+
+        describe("writing to a stream via generic extension function") {
+            val output = ByteArrayOutputStream()
+            Yaml.default.encodeToStream<String>("hello world", output)
+
+            it("returns the value serialized in the expected YAML form") {
+                expect(output.toString(Charsets.UTF_8)).toEqual("\"hello world\"\n")
+            }
+        }
     }
 })


### PR DESCRIPTION
Fixes #246.

Note that this was done via GitHub's web interface, so this exact change is untested. I have tested the `decodeFromStream` extension function locally in a downstream project, though.

The implementation (along with the KDoc comments) mirrors the one in [kotlinx.serialization.SerialFormat](https://github.com/Kotlin/kotlinx.serialization/blob/v1.3.2/core/commonMain/src/kotlinx/serialization/SerialFormat.kt#L84-L97).