### PR TITLE
Added Configuration Support for Ignoring Empty Document

### DIFF
--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlConfiguration.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlConfiguration.kt
@@ -43,6 +43,7 @@ public data class YamlConfiguration constructor(
     internal val sequenceStyle: SequenceStyle = SequenceStyle.Block,
     internal val singleLineStringStyle: SingleLineStringStyle = SingleLineStringStyle.DoubleQuoted,
     internal val multiLineStringStyle: MultiLineStringStyle = singleLineStringStyle.multiLineStringStyle,
+    internal val ignoreEmptyDocument: Boolean = false,
 )
 
 public enum class PolymorphismStyle {

--- a/src/jvmMain/kotlin/com/charleskorn/kaml/Yaml.kt
+++ b/src/jvmMain/kotlin/com/charleskorn/kaml/Yaml.kt
@@ -49,7 +49,7 @@ public actual class Yaml(
     }
 
     private fun <T> decodeFromReader(deserializer: DeserializationStrategy<T>, source: Reader): T {
-        val parser = YamlParser(source)
+        val parser = YamlParser(source, configuration.ignoreEmptyDocument)
         val reader = YamlNodeReader(parser, configuration.extensionDefinitionPrefix)
         val rootNode = reader.read()
         parser.ensureEndOfStreamReached()

--- a/src/jvmMain/kotlin/com/charleskorn/kaml/YamlParser.kt
+++ b/src/jvmMain/kotlin/com/charleskorn/kaml/YamlParser.kt
@@ -26,8 +26,8 @@ import org.snakeyaml.engine.v2.scanner.StreamReader
 import java.io.Reader
 import java.io.StringReader
 
-internal class YamlParser(reader: Reader) {
-    internal constructor(source: String) : this(StringReader(source))
+internal class YamlParser(reader: Reader, ignoreEmptyDocument: Boolean = false) {
+    internal constructor(source: String, ignoreEmptyDocument: Boolean = false) : this(StringReader(source), ignoreEmptyDocument)
 
     private val dummyFileName = "DUMMY_FILE_NAME"
     private val loadSettings = LoadSettings.builder().setLabel(dummyFileName).build()
@@ -37,7 +37,7 @@ internal class YamlParser(reader: Reader) {
     init {
         consumeEventOfType(Event.ID.StreamStart, YamlPath.root)
 
-        if (peekEvent(YamlPath.root).eventId == Event.ID.StreamEnd) {
+        if (peekEvent(YamlPath.root).eventId == Event.ID.StreamEnd && !ignoreEmptyDocument) {
             throw EmptyYamlDocumentException("The YAML document is empty.", YamlPath.root)
         }
 


### PR DESCRIPTION
This adds `ignoreEmptyDocument` to the Configuration (default false)

When true, it doesnt throw an `EmptyYamlDocumentException` when the document is empty.