### PR TITLE
Added experimental comment support on serialization

### DIFF
--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlComment.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlComment.kt
@@ -1,3 +1,21 @@
+/*
+
+   Copyright 2018-2021 Charles Korn.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+*/
+
 package com.charleskorn.kaml
 
 import kotlinx.serialization.ExperimentalSerializationApi

--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlComment.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlComment.kt
@@ -5,12 +5,12 @@ import kotlinx.serialization.SerialInfo
 
 /**
  * Adds a comment block before property on serialization
- * @param comment comment to add. Multiline commment indent will be trimmed automatically
+ * @property lines comment lines to add
  */
-@ExperimentalSerializationApi
+@OptIn(ExperimentalSerializationApi::class)
 @Target(AnnotationTarget.PROPERTY)
 @Retention(AnnotationRetention.BINARY)
 @SerialInfo
 public annotation class YamlComment(
-    val comment: String
+    vararg val lines: String
 )

--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlComment.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlComment.kt
@@ -1,0 +1,16 @@
+package com.charleskorn.kaml
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerialInfo
+
+/**
+ * Adds a comment block before property on serialization
+ * @param comment comment to add. Multiline commment indent will be trimmed automatically
+ */
+@ExperimentalSerializationApi
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.BINARY)
+@SerialInfo
+public annotation class YamlComment(
+    val comment: String
+)

--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlConfiguration.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlConfiguration.kt
@@ -43,7 +43,6 @@ public data class YamlConfiguration constructor(
     internal val sequenceStyle: SequenceStyle = SequenceStyle.Block,
     internal val singleLineStringStyle: SingleLineStringStyle = SingleLineStringStyle.DoubleQuoted,
     internal val multiLineStringStyle: MultiLineStringStyle = singleLineStringStyle.multiLineStringStyle,
-    internal val serializeComments: Boolean = false,
 )
 
 public enum class PolymorphismStyle {

--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlConfiguration.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlConfiguration.kt
@@ -43,6 +43,7 @@ public data class YamlConfiguration constructor(
     internal val sequenceStyle: SequenceStyle = SequenceStyle.Block,
     internal val singleLineStringStyle: SingleLineStringStyle = SingleLineStringStyle.DoubleQuoted,
     internal val multiLineStringStyle: MultiLineStringStyle = singleLineStringStyle.multiLineStringStyle,
+    internal val serializeComments: Boolean = false,
 )
 
 public enum class PolymorphismStyle {

--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlWritingTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlWritingTest.kt
@@ -898,7 +898,7 @@ class YamlWritingTest : DescribeSpec({
                         # Testing
                         # multiline
                         test: "justTest"
-                        """.trimIndent()
+                    """.trimIndent()
                 }
             }
         }

--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlWritingTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlWritingTest.kt
@@ -32,7 +32,6 @@ import com.charleskorn.kaml.testobjects.polymorphicModule
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
-import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.PolymorphicSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.ListSerializer
@@ -888,16 +887,16 @@ class YamlWritingTest : DescribeSpec({
         }
 
         describe("handling comments") {
-            context("comments in Java object") {
+            context("comments in kotlin object") {
                 val input = SimpleStructureWithComments("objName", 73, "justTest")
 
                 it("is written") {
                     Yaml.default.encodeToString(SimpleStructureWithComments.serializer(), input) shouldBe """
                         name: "objName"
-                        #Cool int
+                        # Cool int
                         myInt: 73
-                        #Testing
-                        #multiline
+                        # Testing
+                        # multiline
                         test: "justTest"
                         """.trimIndent()
                 }
@@ -916,16 +915,15 @@ private data class SimpleStructureWithDefault(
     val name: String = "default"
 )
 
-@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 private data class SimpleStructureWithComments(
     val name: String,
     @YamlComment("Cool int")
     val myInt: Int,
-    @YamlComment("""
-        Testing
-        multiline
-    """)
+    @YamlComment(
+        "Testing",
+        "multiline"
+    )
     val test: String
 )
 

--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlWritingTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlWritingTest.kt
@@ -32,6 +32,7 @@ import com.charleskorn.kaml.testobjects.polymorphicModule
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.PolymorphicSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.ListSerializer
@@ -885,6 +886,23 @@ class YamlWritingTest : DescribeSpec({
                 }
             }
         }
+
+        describe("handling comments") {
+            context("comments in Java object") {
+                val input = SimpleStructureWithComments("objName", 73, "justTest")
+
+                it("is written") {
+                    Yaml.default.encodeToString(SimpleStructureWithComments.serializer(), input) shouldBe """
+                        name: "objName"
+                        #Cool int
+                        myInt: 73
+                        #Testing
+                        #multiline
+                        test: "justTest"
+                        """.trimIndent()
+                }
+            }
+        }
     }
 })
 
@@ -896,6 +914,19 @@ class YamlWritingTest : DescribeSpec({
 @Serializable
 private data class SimpleStructureWithDefault(
     val name: String = "default"
+)
+
+@OptIn(ExperimentalSerializationApi::class)
+@Serializable
+private data class SimpleStructureWithComments(
+    val name: String,
+    @YamlComment("Cool int")
+    val myInt: Int,
+    @YamlComment("""
+        Testing
+        multiline
+    """)
+    val test: String
 )
 
 @Serializable

--- a/src/jvmMain/kotlin/com/charleskorn/kaml/YamlOutput.kt
+++ b/src/jvmMain/kotlin/com/charleskorn/kaml/YamlOutput.kt
@@ -154,7 +154,7 @@ internal class YamlOutput(
         if (commentAnno == null) {
             return
         }
-        
+
         for (line in commentAnno.lines) {
             emitter.emit(CommentEvent(CommentType.BLOCK, " $line", Optional.empty(), Optional.empty()))
         }

--- a/src/jvmMain/kotlin/com/charleskorn/kaml/YamlOutput.kt
+++ b/src/jvmMain/kotlin/com/charleskorn/kaml/YamlOutput.kt
@@ -151,15 +151,12 @@ internal class YamlOutput(
             .filterIsInstance<YamlComment>()
             .firstOrNull()
 
-        if(commentAnno != null) {
-            for (line in commentAnno.lines) {
-                emitter.emit(CommentEvent(CommentType.BLOCK, " $line", Optional.empty(), Optional.empty()))
-            }
-            // FIXME: add `inline` annotation parameter and uncomment when kotlin serialization issue 1956 will be resovled
-            // (default parameters on annotations marked with @SerialInfo will throw an exception currently)
-            // Issue link: https://github.com/Kotlin/kotlinx.serialization/issues/1956
-            /*if(commentAnno.inline.isNotEmpty())
-                emitter.emit(CommentEvent(CommentType.IN_LINE, " ${ commentAnno.inline }", Optional.empty(), Optional.empty()))*/
+        if (commentAnno == null) {
+            return
+        }
+        
+        for (line in commentAnno.lines) {
+            emitter.emit(CommentEvent(CommentType.BLOCK, " $line", Optional.empty(), Optional.empty()))
         }
     }
 


### PR DESCRIPTION
Hi. I've created an annotation to add comments for properties on serialization. This PR could be improved so I'm waiting for any suggestions (or PR rejection)
Some questions:
- Should `@YamlComment` annotation be marked as `@ExperimentalSerializationApi`?
- Do you want configuration value to disable comment serialization?
- Are tests good enough or there should be more?

P.s.: Edits by maintainers should be allowed too