### PR TITLE
feat: support for text block

### DIFF
--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlComment.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlComment.kt
@@ -18,6 +18,8 @@
 
 package com.charleskorn.kaml
 
+import com.charleskorn.kaml.TrimType.TRIM_INDENT
+import com.charleskorn.kaml.TrimType.TRIM_MARGIN
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialInfo
 
@@ -30,5 +32,30 @@ import kotlinx.serialization.SerialInfo
 @Retention(AnnotationRetention.BINARY)
 @SerialInfo
 public annotation class YamlComment(
-    vararg val lines: String
+    vararg val lines: String,
 )
+
+/**
+ * Trim type for [YamlComment], if not specified uses [TRIM_INDENT]
+ *
+ * @see TrimType
+ */
+@OptIn(ExperimentalSerializationApi::class)
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.BINARY)
+@SerialInfo
+public annotation class YamlCommentTrim(
+    val trimType: TrimType,
+)
+
+/**
+ * Trim type for [YamlComment.lines]
+ *
+ * @property TRIM_INDENT uses [String.trimIndent]
+ * @property TRIM_MARGIN uses [String.trimMargin]
+ */
+public enum class TrimType {
+    NONE,
+    TRIM_INDENT,
+    TRIM_MARGIN,
+}

--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlWritingTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlWritingTest.kt
@@ -888,7 +888,7 @@ class YamlWritingTest : DescribeSpec({
 
         describe("handling comments") {
             context("comments in kotlin object") {
-                val input = SimpleStructureWithComments("objName", 73, "justTest")
+                val input = SimpleStructureWithComments("objName", 73, "justTest", "test3Quotes", 10, 20)
 
                 it("is written") {
                     Yaml.default.encodeToString(SimpleStructureWithComments.serializer(), input) shouldBe """
@@ -898,6 +898,20 @@ class YamlWritingTest : DescribeSpec({
                         # Testing
                         # multiline
                         test: "justTest"
+                        # Test
+                        # For
+                        # Three quotes
+                        test3Quote: "test3Quotes"
+                        # Test
+                        #  For
+                        #    Trim Margin
+                        testMarginIndent: 10
+                        # 
+                        #     Test
+                        #     For none trim
+                        #     .
+                        # 
+                        testNoneTrim: 20
                     """.trimIndent()
                 }
             }
@@ -924,7 +938,33 @@ private data class SimpleStructureWithComments(
         "Testing",
         "multiline"
     )
-    val test: String
+    val test: String,
+    @YamlComment(
+        """
+        Test
+        For
+        Three quotes
+        """,
+    )
+    val test3Quote: String,
+    @YamlComment(
+        """
+           |Test
+           | For
+           |   Trim Margin
+        """,
+    )
+    @YamlCommentTrim(TrimType.TRIM_MARGIN)
+    val testMarginIndent: Int,
+    @YamlComment(
+        """
+    Test
+    For none trim
+    .
+""",
+    )
+    @YamlCommentTrim(TrimType.NONE)
+    val testNoneTrim: Int,
 )
 
 @Serializable


### PR DESCRIPTION
#287 works well with oneline comment and multiple argument.

But do not support for text block.

Text block will cause runtime-error. 

Like this:

```kotlin
// Source code
@YamlComment(
"""
Max pool size
Default and Recommended Value:
  SQLite: 1, because SQLite has no multi-connection support
  PostgresQL: Processor Threads, like 12 for 6-core machine
    see more: https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
""")
```

```yaml
# Yaml file
#
            Max pool size
            Default and Recommended Value:
              SQLite: 1, because SQLite has no multi-connection support
              PostgresQL: Processor Threads, like 12 for 6-core machine
                see more: https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
```

I add a new Annotation `YamlCommentTrim` to fix this issue. I don't know if it's best practice. At first, I try to add a `trimType` parameter with default value for `YamlComment`, but caused build-error.