### PR TITLE
Add parsing to YamlNode

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,30 @@ val result = Yaml.default.encodeToString(Team.serializer(), input)
 println(result)
 ```
 
+### Parsing into YamlNode
+
+It is possible to parse a string or an InputStream directly into a YamlNode, for example
+the following code prints `Cindy`.
+```kotlin
+val input = """
+        leader: Amy
+        members:
+          - Bob
+          - Cindy
+          - Dan
+    """.trimIndent()
+
+val result = Yaml.default.parseToYamlNode(input)
+
+println(
+    result
+        .yamlMap.get<YamlNode>("members")!!
+        .yamlList[1]
+        .yamlScalar
+        .content
+)
+```
+
 ## Referencing kaml
 
 Add the following to your Gradle build script:

--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlNode.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlNode.kt
@@ -116,6 +116,8 @@ public data class YamlList(val items: List<YamlNode>, override val path: YamlPat
         return this.items.zip(other.items).all { (mine, theirs) -> mine.equivalentContentTo(theirs) }
     }
 
+    public operator fun get(index: Int): YamlNode = items[index]
+
     override fun contentToString(): String = "[" + items.joinToString(", ") { it.contentToString() } + "]"
 
     override fun withPath(newPath: YamlPath): YamlList {
@@ -247,4 +249,23 @@ public data class YamlTaggedNode(val tag: String, val innerNode: YamlNode) : Yam
     override fun withPath(newPath: YamlPath): YamlNode = this.copy(innerNode = innerNode.withPath(newPath))
 
     override fun toString(): String = "tagged '$tag': $innerNode"
+}
+
+public val YamlNode.yamlScalar: YamlScalar
+    get() = this as? YamlScalar ?: error(this, "YamlScalar")
+
+public val YamlNode.yamlNull: YamlNull
+    get() = this as? YamlNull ?: error(this, "YamlNull")
+
+public val YamlNode.yamlList: YamlList
+    get() = this as? YamlList ?: error(this, "YamlList")
+
+public val YamlNode.yamlMap: YamlMap
+    get() = this as? YamlMap ?: error(this, "YamlMap")
+
+public val YamlNode.yamlTaggedNode: YamlTaggedNode
+    get() = this as? YamlTaggedNode ?: error(this, "YamlTaggedNode")
+
+private fun error(node: YamlNode, expectedType: String): Nothing {
+    throw IncorrectTypeException("Element is not $expectedType", node.path)
 }

--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlListTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlListTest.kt
@@ -18,6 +18,7 @@
 
 package com.charleskorn.kaml
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 
@@ -72,6 +73,29 @@ class YamlListTest : DescribeSpec({
                 it("indicates that they are not equivalent") {
                     list.equivalentContentTo(YamlMap(emptyMap(), list.path)) shouldBe false
                 }
+            }
+        }
+
+        describe("getting elements from a list") {
+            val firstItemPath = YamlPath.root.withListEntry(0, Location(4, 5))
+            val secondItemPath = YamlPath.root.withListEntry(1, Location(6, 7))
+
+            val list = YamlList(
+                listOf(
+                    YamlScalar("item 1", firstItemPath),
+                    YamlScalar("item 2", secondItemPath)
+                ),
+                YamlPath.root
+            )
+
+            it("returns element") {
+                list[0] shouldBe YamlScalar("item 1", firstItemPath)
+                list[1] shouldBe YamlScalar("item 2", secondItemPath)
+            }
+
+            it("throws IndexOutOfBoundsException") {
+                shouldThrow<IndexOutOfBoundsException> { list[2] }
+                shouldThrow<IndexOutOfBoundsException> { list[10] }
             }
         }
 

--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlNodeTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlNodeTest.kt
@@ -1,0 +1,60 @@
+/*
+
+   Copyright 2018-2021 Charles Korn.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+*/
+
+package com.charleskorn.kaml
+
+import io.kotest.assertions.asClue
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+class YamlNodeTest : DescribeSpec({
+    describe("converting from YamlNode") {
+        val path = YamlPath.root
+
+        val cases = listOf(
+            Triple("YamlScalar", YamlNode::yamlScalar, YamlScalar("test", path)),
+            Triple("YamlNull", YamlNode::yamlNull, YamlNull(path)),
+            Triple("YamlList", YamlNode::yamlList, YamlList(emptyList(), path)),
+            Triple("YamlMap", YamlNode::yamlMap, YamlMap(emptyMap(), path)),
+            Triple(
+                "YamlTaggedNode", YamlNode::yamlTaggedNode,
+                YamlTaggedNode("tag", YamlScalar("tagged_scalar", path))
+            ),
+        )
+
+        cases.forEach { (fromType, _, value) ->
+            cases.forEach { (toType, method, _) ->
+                if (fromType == toType) {
+                    it("successfully converts to $toType") {
+                        shouldNotThrowAny { method(value) }
+                    }
+                } else {
+                    it("throws when converting to $toType") {
+                        val exception = shouldThrow<IncorrectTypeException> { method(value) }
+                        exception.asClue {
+                            it.message shouldBe "Element is not $toType"
+                            it.path shouldBe path
+                        }
+                    }
+                }
+            }
+        }
+    }
+})

--- a/src/jvmMain/kotlin/com/charleskorn/kaml/Yaml.kt
+++ b/src/jvmMain/kotlin/com/charleskorn/kaml/Yaml.kt
@@ -49,13 +49,22 @@ public actual class Yaml(
     }
 
     private fun <T> decodeFromReader(deserializer: DeserializationStrategy<T>, source: Reader): T {
-        val parser = YamlParser(source)
-        val reader = YamlNodeReader(parser, configuration.extensionDefinitionPrefix)
-        val rootNode = reader.read()
-        parser.ensureEndOfStreamReached()
+        val rootNode = parseToYamlNodeFromReader(source)
 
         val input = YamlInput.createFor(rootNode, serializersModule, configuration, deserializer.descriptor)
         return input.decodeSerializableValue(deserializer)
+    }
+
+    public fun parseToYamlNode(string: String): YamlNode = parseToYamlNodeFromReader(StringReader(string))
+
+    public fun parseToYamlNode(source: InputStream): YamlNode = parseToYamlNodeFromReader(InputStreamReader(source))
+
+    private fun parseToYamlNodeFromReader(source: Reader): YamlNode {
+        val parser = YamlParser(source)
+        val reader = YamlNodeReader(parser, configuration.extensionDefinitionPrefix)
+        val node = reader.read()
+        parser.ensureEndOfStreamReached()
+        return node
     }
 
     override fun <T> encodeToString(serializer: SerializationStrategy<T>, value: T): String {

--- a/src/jvmTest/kotlin/com/charleskorn/kaml/JvmYamlReadingTest.kt
+++ b/src/jvmTest/kotlin/com/charleskorn/kaml/JvmYamlReadingTest.kt
@@ -42,5 +42,23 @@ class JvmYamlReadingTest : DescribeSpec({
                 result shouldBe 123
             }
         }
+
+        describe("parsing into a YamlNode from a string") {
+            val input = "123"
+            val result = Yaml.default.parseToYamlNode(input)
+
+            it("successfully deserializes values from a string") {
+                result.yamlScalar.toInt() shouldBe 123
+            }
+        }
+
+        describe("parsing into a YamlNode from a stream") {
+            val input = "123"
+            val result = Yaml.default.parseToYamlNode(ByteArrayInputStream(input.toByteArray(Charsets.UTF_8)))
+
+            it("successfully deserializes values from a stream") {
+                result.yamlScalar.toInt() shouldBe 123
+            }
+        }
     }
 })


### PR DESCRIPTION
Add the ability to deserialize yaml data without a rigid schema.

I've recently found myself needing to deserialize some yaml data where I wished I could use something like [parseToJsonElement](https://kotlin.github.io/kotlinx.serialization/kotlinx-serialization-json/kotlinx.serialization.json/-json/parse-to-json-element.html). Unfortunately, there was no way to get a YamlNode to do manual parsing, so here I add parseToYamlNode.
I also add a few convenience functions similar to what kotlinx.serialization has for json.

Partly addresses #231, specifically the deserialization part.