### PR TITLE
Initial implementation of Yaml*Serializers

### DIFF
--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlMapInput.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlMapInput.kt
@@ -24,7 +24,7 @@ import kotlinx.serialization.encoding.CompositeDecoder
 import kotlinx.serialization.modules.SerializersModule
 
 @OptIn(ExperimentalSerializationApi::class)
-internal class YamlMapInput(map: YamlMap, context: SerializersModule, configuration: YamlConfiguration) : YamlMapLikeInputBase(map, context, configuration) {
+internal class YamlMapInput(val map: YamlMap, context: SerializersModule, configuration: YamlConfiguration) : YamlMapLikeInputBase(map, context, configuration) {
     private val entriesList = map.entries.entries.toList()
     private var nextIndex = 0
     private lateinit var currentEntry: Map.Entry<YamlScalar, YamlNode>

--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlNode.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlNode.kt
@@ -18,6 +18,9 @@
 
 package com.charleskorn.kaml
 
+import kotlinx.serialization.Serializable
+
+@Serializable(with = YamlNodeSerializer::class)
 public sealed class YamlNode(public open val path: YamlPath) {
     public val location: Location
         get() = path.endLocation
@@ -30,6 +33,7 @@ public sealed class YamlNode(public open val path: YamlPath) {
         YamlPath(newParentPath.segments + child.path.segments.drop(path.segments.size))
 }
 
+@Serializable(with = YamlScalarSerializer::class)
 public data class YamlScalar(val content: String, override val path: YamlPath) : YamlNode(path) {
     override fun equivalentContentTo(other: YamlNode): Boolean = other is YamlScalar && this.content == other.content
     override fun contentToString(): String = "'$content'"
@@ -96,6 +100,7 @@ public data class YamlScalar(val content: String, override val path: YamlPath) :
     override fun toString(): String = "scalar @ $path : $content"
 }
 
+@Serializable(with = YamlNullSerializer::class)
 public data class YamlNull(override val path: YamlPath) : YamlNode(path) {
     override fun equivalentContentTo(other: YamlNode): Boolean = other is YamlNull
     override fun contentToString(): String = "null"
@@ -103,6 +108,7 @@ public data class YamlNull(override val path: YamlPath) : YamlNode(path) {
     override fun toString(): String = "null @ $path"
 }
 
+@Serializable(with = YamlListSerializer::class)
 public data class YamlList(val items: List<YamlNode>, override val path: YamlPath) : YamlNode(path) {
     override fun equivalentContentTo(other: YamlNode): Boolean {
         if (other !is YamlList) {
@@ -144,6 +150,7 @@ public data class YamlList(val items: List<YamlNode>, override val path: YamlPat
     }
 }
 
+@Serializable(with = YamlMapSerializer::class)
 public data class YamlMap(val entries: Map<YamlScalar, YamlNode>, override val path: YamlPath) : YamlNode(path) {
     init {
         val keys = entries.keys.sortedWith { a, b ->
@@ -232,6 +239,7 @@ public data class YamlMap(val entries: Map<YamlScalar, YamlNode>, override val p
     }
 }
 
+@Serializable(with = YamlTaggedNodeSerializer::class)
 public data class YamlTaggedNode(val tag: String, val innerNode: YamlNode) : YamlNode(innerNode.path) {
     override fun equivalentContentTo(other: YamlNode): Boolean {
         if (other !is YamlTaggedNode) {

--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlNodeSerializer.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlNodeSerializer.kt
@@ -1,0 +1,190 @@
+/*
+
+   Copyright 2018-2021 Charles Korn.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+*/
+
+@file:OptIn(ExperimentalSerializationApi::class)
+
+package com.charleskorn.kaml
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializer
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.SerialKind
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+private fun defer(deferred: () -> SerialDescriptor): SerialDescriptor = object : SerialDescriptor {
+
+    private val original: SerialDescriptor by lazy(deferred)
+
+    override val serialName: String
+        get() = original.serialName
+    override val kind: SerialKind
+        get() = original.kind
+    override val elementsCount: Int
+        get() = original.elementsCount
+
+    override fun getElementName(index: Int): String = original.getElementName(index)
+    override fun getElementIndex(name: String): Int = original.getElementIndex(name)
+    override fun getElementAnnotations(index: Int): List<Annotation> = original.getElementAnnotations(index)
+    override fun getElementDescriptor(index: Int): SerialDescriptor = original.getElementDescriptor(index)
+    override fun isElementOptional(index: Int): Boolean = original.isElementOptional(index)
+}
+
+private val Decoder.currentPath: YamlPath
+    get() {
+        return if (this is YamlInput) {
+            getCurrentPath()
+        } else {
+            // TODO not sure if this is a good idea or if it should just fail
+            YamlPath.root
+        }
+    }
+
+@Serializer(forClass = YamlNode::class)
+public object YamlNodeSerializer : KSerializer<YamlNode> {
+    override val descriptor: SerialDescriptor = buildClassSerialDescriptor("com.charleskorn.kaml.YamlNode") {
+        // Resolve cyclic dependency in descriptors by late binding
+        element("YamlScalar", defer { YamlScalarSerializer.descriptor })
+        element("YamlNull", defer { YamlNullSerializer.descriptor })
+        element("YamlMap", defer { YamlMapSerializer.descriptor })
+        element("YamlList", defer { YamlListSerializer.descriptor })
+        element("YamlTaggedNode", defer { YamlTaggedNodeSerializer.descriptor })
+    }
+
+    override fun deserialize(decoder: Decoder): YamlNode {
+        return (decoder as YamlInput).node
+    }
+
+    override fun serialize(encoder: Encoder, value: YamlNode) {
+        when (value) {
+            is YamlList -> YamlListSerializer.serialize(encoder, value)
+            is YamlMap -> YamlMapSerializer.serialize(encoder, value)
+            is YamlNull -> YamlNullSerializer.serialize(encoder, value)
+            is YamlScalar -> YamlScalarSerializer.serialize(encoder, value)
+            is YamlTaggedNode -> YamlTaggedNodeSerializer.serialize(encoder, value)
+        }
+    }
+}
+
+@Serializer(forClass = YamlTaggedNode::class)
+public object YamlTaggedNodeSerializer : KSerializer<YamlTaggedNode> {
+
+    // TODO this has practically no support for tags...
+
+    private object YamlTaggedNodeDescriptor : SerialDescriptor by YamlNodeSerializer.descriptor {
+        override val serialName: String = "com.charleskorn.kaml.YamlTaggedNode"
+    }
+
+    override val descriptor: SerialDescriptor = YamlTaggedNodeDescriptor
+    override fun deserialize(decoder: Decoder): YamlTaggedNode {
+        return YamlTaggedNode("", YamlNodeSerializer.deserialize(decoder))
+    }
+
+    override fun serialize(encoder: Encoder, value: YamlTaggedNode) {
+        YamlNodeSerializer.serialize(encoder, value.innerNode)
+    }
+}
+
+@Serializer(forClass = YamlNull::class)
+public object YamlNullSerializer : KSerializer<YamlNull> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("com.charleskorn.kaml.YamlNull", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): YamlNull {
+        if (decoder is YamlNullInput) {
+            return decoder.nullValue
+        }
+        decoder.decodeNull()
+        return YamlNull(decoder.currentPath)
+    }
+
+    override fun serialize(encoder: Encoder, value: YamlNull) {
+        encoder.encodeNull()
+    }
+}
+
+@Serializer(forClass = YamlScalar::class)
+public object YamlScalarSerializer : KSerializer<YamlScalar> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("com.charleskorn.kaml.YamlScalar", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): YamlScalar {
+        if (decoder is YamlScalarInput) {
+            return decoder.scalar
+        }
+        println("########## ${decoder::class.java.name}")
+        return (decoder as YamlInput).node as YamlScalar
+    }
+
+    override fun serialize(encoder: Encoder, value: YamlScalar) {
+        encoder as YamlOutput
+        encoder.emitPlainScalar(value.content)
+    }
+}
+
+@Serializer(forClass = YamlList::class)
+public object YamlListSerializer : KSerializer<YamlList> {
+    private val listSerializer = ListSerializer(YamlNodeSerializer)
+
+    private object YamlMapDescriptor :
+        SerialDescriptor by listSerializer.descriptor {
+        override val serialName: String = "com.charleskorn.kaml.YamlList"
+    }
+
+    override val descriptor: SerialDescriptor = YamlMapDescriptor
+
+    override fun deserialize(decoder: Decoder): YamlList {
+        if (decoder is YamlListInput) {
+            return decoder.list
+        }
+        return YamlList(listSerializer.deserialize(decoder), decoder.currentPath)
+    }
+
+    override fun serialize(encoder: Encoder, value: YamlList) {
+        return listSerializer.serialize(encoder, value.items)
+    }
+}
+
+@Serializer(forClass = YamlMap::class)
+public object YamlMapSerializer : KSerializer<YamlMap> {
+    private val mapSerializer = MapSerializer(YamlScalarSerializer, YamlNodeSerializer)
+
+    private object YamlMapDescriptor :
+        SerialDescriptor by mapSerializer.descriptor {
+        override val serialName: String = "com.charleskorn.kaml.YamlMap"
+    }
+
+    override val descriptor: SerialDescriptor = YamlMapDescriptor
+
+    override fun deserialize(decoder: Decoder): YamlMap {
+        if (decoder is YamlMapInput) {
+            return decoder.map
+        }
+        return YamlMap(mapSerializer.deserialize(decoder), decoder.currentPath)
+    }
+
+    override fun serialize(encoder: Encoder, value: YamlMap) {
+        return mapSerializer.serialize(encoder, value.entries)
+    }
+}

--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlNullInput.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlNullInput.kt
@@ -24,7 +24,7 @@ import kotlinx.serialization.encoding.CompositeDecoder
 import kotlinx.serialization.modules.SerializersModule
 
 @OptIn(ExperimentalSerializationApi::class)
-internal class YamlNullInput(val nullValue: YamlNode, context: SerializersModule, configuration: YamlConfiguration) : YamlInput(nullValue, context, configuration) {
+internal class YamlNullInput(val nullValue: YamlNull, context: SerializersModule, configuration: YamlConfiguration) : YamlInput(nullValue, context, configuration) {
     override fun decodeNotNullMark(): Boolean = false
 
     override fun decodeValue(): Any = throw UnexpectedNullValueException(nullValue.path)

--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlOutput.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlOutput.kt
@@ -1,0 +1,23 @@
+/*
+
+   Copyright 2018-2021 Charles Korn.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+*/
+
+package com.charleskorn.kaml
+
+internal expect class YamlOutput {
+    internal fun emitPlainScalar(value: String)
+}

--- a/src/jvmMain/kotlin/com/charleskorn/kaml/YamlOutput.kt
+++ b/src/jvmMain/kotlin/com/charleskorn/kaml/YamlOutput.kt
@@ -45,7 +45,7 @@ import org.snakeyaml.engine.v2.events.StreamStartEvent
 import java.util.Optional
 
 @OptIn(ExperimentalSerializationApi::class)
-internal class YamlOutput(
+internal actual class YamlOutput(
     writer: StreamDataWriter,
     override val serializersModule: SerializersModule,
     private val configuration: YamlConfiguration
@@ -88,7 +88,7 @@ internal class YamlOutput(
 
     override fun encodeEnum(enumDescriptor: SerialDescriptor, index: Int) = emitQuotedScalar(enumDescriptor.getElementName(index), configuration.singleLineStringStyle.scalarStyle)
 
-    private fun emitPlainScalar(value: String) = emitScalar(value, ScalarStyle.PLAIN)
+    internal actual fun emitPlainScalar(value: String) = emitScalar(value, ScalarStyle.PLAIN)
     private fun emitQuotedScalar(value: String, scalarStyle: ScalarStyle) = emitScalar(value, scalarStyle)
 
     override fun encodeElement(descriptor: SerialDescriptor, index: Int): Boolean {

--- a/src/jvmTest/kotlin/com/charleskorn/kaml/JvmYamlNodeSerializationTest.kt
+++ b/src/jvmTest/kotlin/com/charleskorn/kaml/JvmYamlNodeSerializationTest.kt
@@ -1,0 +1,113 @@
+/*
+
+   Copyright 2018-2021 Charles Korn.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+*/
+
+package com.charleskorn.kaml
+
+import com.charleskorn.kaml.YamlPathSegment.MapElementKey
+import com.charleskorn.kaml.YamlPathSegment.MapElementValue
+import com.charleskorn.kaml.YamlPathSegment.Root
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.core.spec.style.scopes.DescribeSpecContainerScope
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+
+@Serializable
+data class YamlNodeWrapper(val yaml: YamlNode)
+
+@Serializable
+data class YamlMapWrapper(val yaml: YamlMap)
+
+@Serializable
+data class YamlListWrapper(val yaml: YamlList)
+
+@Serializable
+data class YamlTaggedNodeWrapper(val yaml: YamlTaggedNode)
+
+@Serializable
+data class YamlScalarWrapper(val yaml: YamlScalar)
+
+@Serializable
+data class YamlNullWrapper(val yaml: YamlNull)
+
+private suspend inline fun <reified T : Any> DescribeSpecContainerScope.roundTrip(name: String, input: T, expectedEncoding: String) {
+    describe(name) {
+        val encoded = Yaml.default.encodeToString(input)
+        val decoded = Yaml.default.decodeFromString<T>(encoded)
+
+        it("correctly serializes") {
+            encoded shouldBe expectedEncoding
+        }
+
+        it("correctly deserializes") {
+            decoded shouldBe input
+        }
+    }
+}
+
+private val path = YamlPath(
+    Root,
+    MapElementKey("yaml", Location(1, 1)),
+    MapElementValue(Location(1, 7)),
+)
+
+class JvmYamlNodeSerializationTest : DescribeSpec({
+    describe("yaml node serializers") {
+        roundTrip(
+            name = "wrapped object",
+            input = YamlMapWrapper(YamlMap(emptyMap(), path)),
+            expectedEncoding = "yaml: {}",
+        )
+        roundTrip(
+            name = "wrapped list",
+            input = YamlListWrapper(YamlList(emptyList(), path)),
+            expectedEncoding = "yaml: []",
+        )
+        roundTrip(
+            name = "wrapped scalar",
+            input = YamlScalarWrapper(YamlScalar("1", path)),
+            expectedEncoding = "yaml: 1",
+        )
+        roundTrip(
+            name = "wrapped null",
+            input = YamlNullWrapper(YamlNull(path)),
+            expectedEncoding = "yaml: null",
+        )
+        roundTrip(
+            name = "wrapped object as node",
+            input = YamlNodeWrapper(YamlMap(emptyMap(), path)),
+            expectedEncoding = "yaml: {}",
+        )
+        roundTrip(
+            name = "wrapped list as node",
+            input = YamlNodeWrapper(YamlList(emptyList(), path)),
+            expectedEncoding = "yaml: []",
+        )
+        roundTrip(
+            name = "wrapped scalar as node",
+            input = YamlNodeWrapper(YamlScalar("1", path)),
+            expectedEncoding = "yaml: 1",
+        )
+        roundTrip(
+            name = "wrapped null as node",
+            input = YamlNodeWrapper(YamlNull(path)),
+            expectedEncoding = "yaml: null",
+        )
+    }
+})


### PR DESCRIPTION
this is still very much broken and there a bunch of open questions, but this could be a viable starting point. This was basically adapted from the Json equivalents. The Json module seems to have more support for this in the Encoder/Decoder directly.

Someone with more knowledge of the inner workings of this module should have a look at this and also at the test failures I'm seeing. 

The idea is to be able to decode and re-encode with these serializers and get the exact same value back, that's what the tests try to verify.

Since I'm switching over to a different approach for my project, I will not be needing this myself, so depending on how much work is left here I may not be able to continue working on this actively.