### PR TITLE
Add a configurable indent for sequences

### DIFF
--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlConfiguration.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlConfiguration.kt
@@ -42,10 +42,10 @@ public data class YamlConfiguration constructor(
     internal val encodingIndentationSize: Int = 2,
     internal val breakScalarsAt: Int = 80,
     internal val sequenceStyle: SequenceStyle = SequenceStyle.Block,
-    internal val sequenceBlockIndent: Int = 0,
     internal val singleLineStringStyle: SingleLineStringStyle = SingleLineStringStyle.DoubleQuoted,
-    internal val multiLineStringStyle: MultiLineStringStyle = singleLineStringStyle.multiLineStringStyle
-)
+    internal val multiLineStringStyle: MultiLineStringStyle = singleLineStringStyle.multiLineStringStyle,
+    internal val sequenceBlockIndent: Int = 0
+    )
 
 public enum class PolymorphismStyle {
     Tag,

--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlConfiguration.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlConfiguration.kt
@@ -31,6 +31,7 @@ package com.charleskorn.kaml
  * * [encodingIndentationSize]: number of spaces to use as indentation when encoding objects as YAML
  * * [breakScalarsAt]: maximum length of scalars when encoding objects as YAML (scalars exceeding this length will be split into multiple lines)
  * * [sequenceStyle]: how sequences (aka lists and arrays) should be formatted. See [SequenceStyle] for an example of each
+ * * [sequenceBlockIndent]: number of spaces to use as indentation for sequences, if set to block mode (0 still includes the `-` character and a space after it)
  */
 public data class YamlConfiguration constructor(
     internal val encodeDefaults: Boolean = true,
@@ -41,6 +42,7 @@ public data class YamlConfiguration constructor(
     internal val encodingIndentationSize: Int = 2,
     internal val breakScalarsAt: Int = 80,
     internal val sequenceStyle: SequenceStyle = SequenceStyle.Block,
+    internal val sequenceBlockIndent: Int = 0,
     internal val singleLineStringStyle: SingleLineStringStyle = SingleLineStringStyle.DoubleQuoted,
     internal val multiLineStringStyle: MultiLineStringStyle = singleLineStringStyle.multiLineStringStyle
 )

--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlConfiguration.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlConfiguration.kt
@@ -45,7 +45,7 @@ public data class YamlConfiguration constructor(
     internal val singleLineStringStyle: SingleLineStringStyle = SingleLineStringStyle.DoubleQuoted,
     internal val multiLineStringStyle: MultiLineStringStyle = singleLineStringStyle.multiLineStringStyle,
     internal val sequenceBlockIndent: Int = 0
-    )
+)
 
 public enum class PolymorphismStyle {
     Tag,

--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlWritingTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlWritingTest.kt
@@ -282,6 +282,21 @@ class YamlWritingTest : DescribeSpec({
                 }
             }
 
+            context("serializing a list of objects with sequence block indent") {
+                @Serializable
+                data class Foo(val bar: String)
+
+                val output = Yaml(configuration = YamlConfiguration(sequenceBlockIndent = 2))
+                    .encodeToString(ListSerializer(Foo.serializer()), listOf(Foo("baz")))
+
+                it("returns the value serialized in the expected YAML form") {
+                    output shouldBe
+                        """
+                        |  - bar: "baz"
+                        """.trimMargin()
+                }
+            }
+
             context("serializing a list of nullable integers in flow form") {
                 val output = Yaml(configuration = YamlConfiguration(sequenceStyle = SequenceStyle.Flow))
                     .encodeToString(ListSerializer(Int.serializer().nullable), listOf(1, null, 3))

--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlWritingTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlWritingTest.kt
@@ -254,7 +254,7 @@ class YamlWritingTest : DescribeSpec({
                 }
             }
 
-            context("serializing a list of integers  with sequence block indent") {
+            context("serializing a list of integers with sequence block indent") {
                 val output = Yaml(configuration = YamlConfiguration(sequenceBlockIndent = 2))
                     .encodeToString(ListSerializer(Int.serializer()), listOf(1, 2, 3))
 

--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlWritingTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlWritingTest.kt
@@ -254,6 +254,20 @@ class YamlWritingTest : DescribeSpec({
                 }
             }
 
+            context("serializing a list of integers without sequence block indent") {
+                val output = Yaml(configuration = YamlConfiguration(sequenceBlockIndent = 0))
+                    .encodeToString(ListSerializer(Int.serializer()), listOf(1, 2, 3))
+
+                it("returns the value serialized in the expected YAML form") {
+                    output shouldBe
+                        """
+                        |- 1
+                        |- 2
+                        |- 3
+                        """.trimMargin()
+                }
+            }
+
             context("serializing a list of integers with sequence block indent") {
                 val output = Yaml(configuration = YamlConfiguration(sequenceBlockIndent = 2))
                     .encodeToString(ListSerializer(Int.serializer()), listOf(1, 2, 3))

--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlWritingTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlWritingTest.kt
@@ -245,6 +245,29 @@ class YamlWritingTest : DescribeSpec({
                 }
             }
 
+            context("serializing a list of integers in flow form with sequence block indent") {
+                val output = Yaml(configuration = YamlConfiguration(sequenceStyle = SequenceStyle.Flow, sequenceBlockIndent = 2))
+                    .encodeToString(ListSerializer(Int.serializer()), listOf(1, 2, 3))
+
+                it("returns the value serialized in the expected YAML form") {
+                    output shouldBe "[1, 2, 3]"
+                }
+            }
+
+            context("serializing a list of integers  with sequence block indent") {
+                val output = Yaml(configuration = YamlConfiguration(sequenceBlockIndent = 2))
+                    .encodeToString(ListSerializer(Int.serializer()), listOf(1, 2, 3))
+
+                it("returns the value serialized in the expected YAML form") {
+                    output shouldBe
+                        """
+                        |  - 1
+                        |  - 2
+                        |  - 3
+                        """.trimMargin()
+                }
+            }
+
             context("serializing a list of nullable integers in flow form") {
                 val output = Yaml(configuration = YamlConfiguration(sequenceStyle = SequenceStyle.Flow))
                     .encodeToString(ListSerializer(Int.serializer().nullable), listOf(1, null, 3))

--- a/src/jvmMain/kotlin/com/charleskorn/kaml/YamlOutput.kt
+++ b/src/jvmMain/kotlin/com/charleskorn/kaml/YamlOutput.kt
@@ -57,6 +57,7 @@ internal class YamlOutput(
         .setIndicatorIndent(configuration.sequenceBlockIndent)
         /*
          This is required to be true to properly handle the serialization of a list of objects.
+         Does not seem to have an impact on a simple top level array.
          This issue becomes apparent when `sequenceBlockIndent` is 2 or more, as it causes invalid yaml.
          Issue is visible if `sequenceBlockIndent` is 1, but is invalid yaml.
 
@@ -79,6 +80,7 @@ internal class YamlOutput(
          |  bar: "baz" # This is NOT valid yaml!
          """.trimMargin()
         ```
+        Expected output is achieved when field is set to true
 
          No special reason why true is conditional. Designed to be consistent with 0.46.0 of kaml
          */

--- a/src/jvmMain/kotlin/com/charleskorn/kaml/YamlOutput.kt
+++ b/src/jvmMain/kotlin/com/charleskorn/kaml/YamlOutput.kt
@@ -55,35 +55,7 @@ internal class YamlOutput(
         .setIndent(configuration.encodingIndentationSize)
         // SnakeYAML helps to validate that this value must be non-negative
         .setIndicatorIndent(configuration.sequenceBlockIndent)
-        /*
-         This is required to be true to properly handle the serialization of a list of objects.
-         Does not seem to have an impact on a simple top level array.
-         This issue becomes apparent when `sequenceBlockIndent` is 2 or more, as it causes invalid yaml.
-         Issue is visible if `sequenceBlockIndent` is 1, but is invalid yaml.
-
-         Smallest reproducible test case:
-
-         ```kotlin
-         @Serializable
-         data class Foo(val bar: String)
-
-         Yaml(configuration = YamlConfiguration(sequenceBlockIndent = 2).encodeToString(listOf(Foo("baz"))))
-
-         Expected output:
-         """
-         |  - bar: "baz"
-         """.trimMargin()
-
-         Actual output:
-         """
-         |  -
-         |  bar: "baz" # This is NOT valid yaml!
-         """.trimMargin()
-        ```
-        Expected output is achieved when field is set to true
-
-         No special reason why true is conditional. Designed to be consistent with 0.46.0 of kaml
-         */
+        // No special reason why true is conditional. Designed to be consistent with 0.46.0 of kaml
         .setIndentWithIndicator(configuration.sequenceBlockIndent > 0)
         // Unclear if this value is validated
         .setWidth(configuration.breakScalarsAt)

--- a/src/jvmMain/kotlin/com/charleskorn/kaml/YamlOutput.kt
+++ b/src/jvmMain/kotlin/com/charleskorn/kaml/YamlOutput.kt
@@ -55,7 +55,33 @@ internal class YamlOutput(
         .setIndent(configuration.encodingIndentationSize)
         // SnakeYAML helps to validate that this value must be non-negative
         .setIndicatorIndent(configuration.sequenceBlockIndent)
-        // No special reason why true is conditional. Designed to be consistent with 0.46.0 of kaml
+        /*
+         This is required to be true to properly handle the serialization of a list of objects.
+         This issue becomes apparent when `sequenceBlockIndent` is 2 or more, as it causes invalid yaml.
+         Issue is visible if `sequenceBlockIndent` is 1, but is invalid yaml.
+
+         Smallest reproducible test case:
+
+         ```kotlin
+         @Serializable
+         data class Foo(val bar: String)
+
+         Yaml(configuration = YamlConfiguration(sequenceBlockIndent = 2).encodeToString(listOf(Foo("baz"))))
+
+         Expected output:
+         """
+         |  - bar: "baz"
+         """.trimMargin()
+
+         Actual output:
+         """
+         |  -
+         |  bar: "baz" # This is NOT valid yaml!
+         """.trimMargin()
+        ```
+
+         No special reason why true is conditional. Designed to be consistent with 0.46.0 of kaml
+         */
         .setIndentWithIndicator(configuration.sequenceBlockIndent > 0)
         // Unclear if this value is validated
         .setWidth(configuration.breakScalarsAt)

--- a/src/jvmMain/kotlin/com/charleskorn/kaml/YamlOutput.kt
+++ b/src/jvmMain/kotlin/com/charleskorn/kaml/YamlOutput.kt
@@ -51,10 +51,13 @@ internal class YamlOutput(
     private val configuration: YamlConfiguration
 ) : AbstractEncoder(), AutoCloseable {
     private val settings = DumpSettings.builder()
+        // SnakeYAML validates that this value must be at least 1
         .setIndent(configuration.encodingIndentationSize)
+        // SnakeYAML helps to validate that this value must be non-negative
         .setIndicatorIndent(configuration.sequenceBlockIndent)
         // No special reason why true is conditional. Designed to be consistent with 0.46.0 of kaml
         .setIndentWithIndicator(configuration.sequenceBlockIndent > 0)
+        // Unclear if this value is validated
         .setWidth(configuration.breakScalarsAt)
         .build()
 

--- a/src/jvmMain/kotlin/com/charleskorn/kaml/YamlOutput.kt
+++ b/src/jvmMain/kotlin/com/charleskorn/kaml/YamlOutput.kt
@@ -181,11 +181,7 @@ internal class YamlOutput(
     private fun encodeComment(descriptor: SerialDescriptor, index: Int) {
         val commentAnno = descriptor.getElementAnnotations(index)
             .filterIsInstance<YamlComment>()
-            .firstOrNull()
-
-        if (commentAnno == null) {
-            return
-        }
+            .firstOrNull() ?: return
 
         for (line in commentAnno.lines) {
             emitter.emit(CommentEvent(CommentType.BLOCK, " $line", Optional.empty(), Optional.empty()))

--- a/src/jvmMain/kotlin/com/charleskorn/kaml/YamlOutput.kt
+++ b/src/jvmMain/kotlin/com/charleskorn/kaml/YamlOutput.kt
@@ -52,6 +52,9 @@ internal class YamlOutput(
 ) : AbstractEncoder(), AutoCloseable {
     private val settings = DumpSettings.builder()
         .setIndent(configuration.encodingIndentationSize)
+        .setIndicatorIndent(configuration.sequenceBlockIndent)
+        // No special reason why true is conditional. Designed to be consistent with 0.46.0 of kaml
+        .setIndentWithIndicator(configuration.sequenceBlockIndent > 0)
         .setWidth(configuration.breakScalarsAt)
         .build()
 


### PR DESCRIPTION
There was previously no configurable indent for sequences. This pr enables this functionality

Previously
```yaml
list:
- 1
- 2
- 3
```

Now with `sequenceBlockIndent` set to `2` (default `0` to preserve backwards compatibility)
```yaml
list:
  - 1
  - 2
  - 3
```