### PR TITLE
Adding test with named enum values

### DIFF
--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlReadingTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlReadingTest.kt
@@ -26,6 +26,7 @@ import com.charleskorn.kaml.testobjects.SealedWrapper
 import com.charleskorn.kaml.testobjects.SimpleStructure
 import com.charleskorn.kaml.testobjects.Team
 import com.charleskorn.kaml.testobjects.TestEnum
+import com.charleskorn.kaml.testobjects.TestEnumWithExplicitNames
 import com.charleskorn.kaml.testobjects.TestSealedStructure
 import com.charleskorn.kaml.testobjects.UnsealedClass
 import com.charleskorn.kaml.testobjects.UnsealedString
@@ -241,13 +242,19 @@ class YamlReadingTest : DescribeSpec({
                 }
             }
 
+            data class EnumFixture(val input: String, val serializer: KSerializer<*>)
+
             mapOf(
-                "Value1" to TestEnum.Value1,
-                "Value2" to TestEnum.Value2,
-            ).forEach { (input, expectedValue) ->
+                EnumFixture("Value1", TestEnum.serializer()) to TestEnum.Value1,
+                EnumFixture("Value2", TestEnum.serializer()) to TestEnum.Value2,
+                EnumFixture("A", TestEnumWithExplicitNames.serializer()) to TestEnumWithExplicitNames.Alpha,
+                EnumFixture("B", TestEnumWithExplicitNames.serializer()) to TestEnumWithExplicitNames.Beta,
+                EnumFixture("With space", TestEnumWithExplicitNames.serializer()) to TestEnumWithExplicitNames.With_Space,
+            ).forEach { (fixture, expectedValue) ->
+                val (input, serializer) = fixture
                 context("given the input '$input'") {
                     context("parsing that input as an enumeration value") {
-                        val result = Yaml.default.decodeFromString(TestEnum.serializer(), input)
+                        val result = Yaml.default.decodeFromString(serializer, input)
 
                         it("deserializes it to the expected enumeration value") {
                             result shouldBe expectedValue

--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlReadingTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlReadingTest.kt
@@ -249,7 +249,7 @@ class YamlReadingTest : DescribeSpec({
                 EnumFixture("Value2", TestEnum.serializer()) to TestEnum.Value2,
                 EnumFixture("A", TestEnumWithExplicitNames.serializer()) to TestEnumWithExplicitNames.Alpha,
                 EnumFixture("B", TestEnumWithExplicitNames.serializer()) to TestEnumWithExplicitNames.Beta,
-                EnumFixture("With space", TestEnumWithExplicitNames.serializer()) to TestEnumWithExplicitNames.With_Space,
+                EnumFixture("With space", TestEnumWithExplicitNames.serializer()) to TestEnumWithExplicitNames.WithSpace,
             ).forEach { (fixture, expectedValue) ->
                 val (input, serializer) = fixture
                 context("given the input '$input'") {

--- a/src/commonTest/kotlin/com/charleskorn/kaml/testobjects/TestObjects.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/testobjects/TestObjects.kt
@@ -52,5 +52,5 @@ enum class TestEnumWithExplicitNames {
     Beta,
 
     @SerialName("With space")
-    With_Space
+    WithSpace,
 }

--- a/src/commonTest/kotlin/com/charleskorn/kaml/testobjects/TestObjects.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/testobjects/TestObjects.kt
@@ -18,6 +18,7 @@
 
 package com.charleskorn.kaml.testobjects
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -40,4 +41,16 @@ data class NestedObjects(
 enum class TestEnum {
     Value1,
     Value2,
+}
+
+@Serializable
+enum class TestEnumWithExplicitNames {
+    @SerialName("A")
+    Alpha,
+
+    @SerialName("B")
+    Beta,
+
+    @SerialName("With space")
+    With_Space
 }


### PR DESCRIPTION
Hi @charleskorn 

I ran into some trouble when parsing an enum with explicit serial names into a config using Hoplite. Was trying to pinpoint the issue, and it seems it's not in KAML 🙂 If you feel there's any value to adding the tests you're welcome to merge this, otherwise just close it. 