### PR TITLE
Add SingleLineStringStyle.PlainExceptAmbiguous and AmbiguousEscapeStyle

### DIFF
--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlConfiguration.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlConfiguration.kt
@@ -31,6 +31,7 @@ package com.charleskorn.kaml
  * * [encodingIndentationSize]: number of spaces to use as indentation when encoding objects as YAML
  * * [breakScalarsAt]: maximum length of scalars when encoding objects as YAML (scalars exceeding this length will be split into multiple lines)
  * * [sequenceStyle]: how sequences (aka lists and arrays) should be formatted. See [SequenceStyle] for an example of each
+ * * [ambiguousEscapeStyle]: how strings should be escaped when [singleLineStringStyle] is [SingleLineStringStyle.PlainExceptAmbiguous] and the value is ambiguous
  * * [sequenceBlockIndent]: number of spaces to use as indentation for sequences, if [sequenceStyle] set to [SequenceStyle.Block]
  */
 public data class YamlConfiguration constructor(
@@ -44,6 +45,7 @@ public data class YamlConfiguration constructor(
     internal val sequenceStyle: SequenceStyle = SequenceStyle.Block,
     internal val singleLineStringStyle: SingleLineStringStyle = SingleLineStringStyle.DoubleQuoted,
     internal val multiLineStringStyle: MultiLineStringStyle = singleLineStringStyle.multiLineStringStyle,
+    internal val ambiguousEscapeStyle: AmbiguousEscapeStyle = AmbiguousEscapeStyle.DoubleQuoted,
     internal val sequenceBlockIndent: Int = 0,
 )
 
@@ -83,12 +85,18 @@ public enum class SingleLineStringStyle {
     DoubleQuoted,
     SingleQuoted,
     Plain,
-    ;
+    PlainExceptAmbiguous;
 
     public val multiLineStringStyle: MultiLineStringStyle
         get() = when (this) {
             DoubleQuoted -> MultiLineStringStyle.DoubleQuoted
             SingleQuoted -> MultiLineStringStyle.SingleQuoted
             Plain -> MultiLineStringStyle.Plain
+            PlainExceptAmbiguous -> MultiLineStringStyle.Plain
         }
+}
+
+public enum class AmbiguousEscapeStyle {
+    DoubleQuoted,
+    SingleQuoted,
 }

--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlConfiguration.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlConfiguration.kt
@@ -31,7 +31,7 @@ package com.charleskorn.kaml
  * * [encodingIndentationSize]: number of spaces to use as indentation when encoding objects as YAML
  * * [breakScalarsAt]: maximum length of scalars when encoding objects as YAML (scalars exceeding this length will be split into multiple lines)
  * * [sequenceStyle]: how sequences (aka lists and arrays) should be formatted. See [SequenceStyle] for an example of each
- * * [ambiguousEscapeStyle]: how strings should be escaped when [singleLineStringStyle] is [SingleLineStringStyle.PlainExceptAmbiguous] and the value is ambiguous
+ * * [ambiguousQuoteStyle]: how strings should be escaped when [singleLineStringStyle] is [SingleLineStringStyle.PlainExceptAmbiguous] and the value is ambiguous
  * * [sequenceBlockIndent]: number of spaces to use as indentation for sequences, if [sequenceStyle] set to [SequenceStyle.Block]
  */
 public data class YamlConfiguration constructor(
@@ -45,7 +45,7 @@ public data class YamlConfiguration constructor(
     internal val sequenceStyle: SequenceStyle = SequenceStyle.Block,
     internal val singleLineStringStyle: SingleLineStringStyle = SingleLineStringStyle.DoubleQuoted,
     internal val multiLineStringStyle: MultiLineStringStyle = singleLineStringStyle.multiLineStringStyle,
-    internal val ambiguousEscapeStyle: AmbiguousEscapeStyle = AmbiguousEscapeStyle.DoubleQuoted,
+    internal val ambiguousQuoteStyle: AmbiguousQuoteStyle = AmbiguousQuoteStyle.DoubleQuoted,
     internal val sequenceBlockIndent: Int = 0,
 )
 
@@ -88,7 +88,7 @@ public enum class SingleLineStringStyle {
 
     /**
      * This is the same as [SingleLineStringStyle.Plain], except strings that could be misinterpreted as other types
-     * will be quoted with the escape style defined in [AmbiguousEscapeStyle].
+     * will be quoted with the escape style defined in [AmbiguousQuoteStyle].
      *
      * For example, the strings "True", "0xAB", "1" and "1.2" would all be quoted,
      * while "1.2.3" and "abc" would not be quoted.
@@ -104,7 +104,7 @@ public enum class SingleLineStringStyle {
         }
 }
 
-public enum class AmbiguousEscapeStyle {
+public enum class AmbiguousQuoteStyle {
     DoubleQuoted,
     SingleQuoted,
 }

--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlConfiguration.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlConfiguration.kt
@@ -93,7 +93,8 @@ public enum class SingleLineStringStyle {
      * For example, the strings "True", "0xAB", "1" and "1.2" would all be quoted,
      * while "1.2.3" and "abc" would not be quoted.
      */
-    PlainExceptAmbiguous;
+    PlainExceptAmbiguous,
+    ;
 
     public val multiLineStringStyle: MultiLineStringStyle
         get() = when (this) {

--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlConfiguration.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlConfiguration.kt
@@ -85,6 +85,23 @@ public enum class SingleLineStringStyle {
     DoubleQuoted,
     SingleQuoted,
     Plain,
+
+    /**
+     * This is the same as [SingleLineStringStyle.Plain], except strings that are not strictly strings in YAML
+     * without quotes will be escaped with the escape style defined in [AmbiguousEscapeStyle].
+     *
+     * True -> Boolean -> Escaped
+     *
+     * 0xAB -> Hexadecimal -> Escaped
+     *
+     * 1 -> Int -> Escaped
+     *
+     * 1.2 -> Float -> Escaped
+     *
+     * 1.2.3 -> Unambiguously a string -> Not escaped
+     *
+     * @since 0.51.0
+     */
     PlainExceptAmbiguous;
 
     public val multiLineStringStyle: MultiLineStringStyle

--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlConfiguration.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlConfiguration.kt
@@ -87,20 +87,11 @@ public enum class SingleLineStringStyle {
     Plain,
 
     /**
-     * This is the same as [SingleLineStringStyle.Plain], except strings that are not strictly strings in YAML
-     * without quotes will be escaped with the escape style defined in [AmbiguousEscapeStyle].
+     * This is the same as [SingleLineStringStyle.Plain], except strings that could be misinterpreted as other types
+     * will be quoted with the escape style defined in [AmbiguousEscapeStyle].
      *
-     * True -> Boolean -> Escaped
-     *
-     * 0xAB -> Hexadecimal -> Escaped
-     *
-     * 1 -> Int -> Escaped
-     *
-     * 1.2 -> Float -> Escaped
-     *
-     * 1.2.3 -> Unambiguously a string -> Not escaped
-     *
-     * @since 0.51.0
+     * For example, the strings "True", "0xAB", "1" and "1.2" would all be quoted,
+     * while "1.2.3" and "abc" would not be quoted.
      */
     PlainExceptAmbiguous;
 

--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlWritingTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlWritingTest.kt
@@ -261,7 +261,7 @@ class YamlWritingTest : DescribeSpec({
                 val output = Yaml(
                     configuration = YamlConfiguration(
                         singleLineStringStyle = SingleLineStringStyle.PlainExceptAmbiguous,
-                        ambiguousEscapeStyle = AmbiguousEscapeStyle.SingleQuoted
+                        ambiguousQuoteStyle = AmbiguousQuoteStyle.SingleQuoted
                     )
                 ).encodeToString(String.serializer(), "12")
 
@@ -274,7 +274,7 @@ class YamlWritingTest : DescribeSpec({
                 val output = Yaml(
                     configuration = YamlConfiguration(
                         singleLineStringStyle = SingleLineStringStyle.PlainExceptAmbiguous,
-                        ambiguousEscapeStyle = AmbiguousEscapeStyle.SingleQuoted
+                        ambiguousQuoteStyle = AmbiguousQuoteStyle.SingleQuoted
                     )
                 ).encodeToString(String.serializer(), "true")
 
@@ -287,7 +287,7 @@ class YamlWritingTest : DescribeSpec({
                 val output = Yaml(
                     configuration = YamlConfiguration(
                         singleLineStringStyle = SingleLineStringStyle.PlainExceptAmbiguous,
-                        ambiguousEscapeStyle = AmbiguousEscapeStyle.SingleQuoted
+                        ambiguousQuoteStyle = AmbiguousQuoteStyle.SingleQuoted
                     )
                 ).encodeToString(String.serializer(), "1.2")
 

--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlWritingTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlWritingTest.kt
@@ -200,6 +200,69 @@ class YamlWritingTest : DescribeSpec({
                         """.trimMargin()
                 }
             }
+
+            context("serializing a string with the value of an integer using SingleLineStringStyle.PlainExceptAmbiguous") {
+                val output = Yaml(configuration = YamlConfiguration(singleLineStringStyle = SingleLineStringStyle.PlainExceptAmbiguous)).encodeToString(String.serializer(), "12")
+
+                it("returns the value serialized in the expected YAML form, escaping the integer") {
+                    output shouldBe """"12""""
+                }
+            }
+
+            context("serializing a string with the value of a boolean using SingleLineStringStyle.PlainExceptAmbiguous") {
+                val output = Yaml(configuration = YamlConfiguration(singleLineStringStyle = SingleLineStringStyle.PlainExceptAmbiguous)).encodeToString(String.serializer(), "true")
+
+                it("returns the value serialized in the expected YAML form, escaping the boolean") {
+                    output shouldBe """"true""""
+                }
+            }
+
+            context("serializing a string with the value of an float using SingleLineStringStyle.PlainExceptAmbiguous") {
+                val output = Yaml(configuration = YamlConfiguration(singleLineStringStyle = SingleLineStringStyle.PlainExceptAmbiguous)).encodeToString(String.serializer(), "1.2")
+
+                it("returns the value serialized in the expected YAML form, escaping the float") {
+                    output shouldBe """"1.2""""
+                }
+            }
+
+            context("serializing a string with the value of an integer using SingleLineStringStyle.PlainExceptAmbiguous, escaping with single-quotes") {
+                val output = Yaml(
+                    configuration = YamlConfiguration(
+                        singleLineStringStyle = SingleLineStringStyle.PlainExceptAmbiguous,
+                        ambiguousEscapeStyle = AmbiguousEscapeStyle.SingleQuoted
+                    )
+                ).encodeToString(String.serializer(), "12")
+
+                it("returns the value serialized in the expected YAML form, escaping the integer with single-quotes") {
+                    output shouldBe """'12'"""
+                }
+            }
+
+            context("serializing a string with the value of a boolean using SingleLineStringStyle.PlainExceptAmbiguous, escaping with single-quotes") {
+                val output = Yaml(
+                    configuration = YamlConfiguration(
+                        singleLineStringStyle = SingleLineStringStyle.PlainExceptAmbiguous,
+                        ambiguousEscapeStyle = AmbiguousEscapeStyle.SingleQuoted
+                    )
+                ).encodeToString(String.serializer(), "true")
+
+                it("returns the value serialized in the expected YAML form, escaping the boolean with single-quotes") {
+                    output shouldBe """'true'"""
+                }
+            }
+
+            context("serializing a string with the value of an float using SingleLineStringStyle.PlainExceptAmbiguous, escaping with single-quotes") {
+                val output = Yaml(
+                    configuration = YamlConfiguration(
+                        singleLineStringStyle = SingleLineStringStyle.PlainExceptAmbiguous,
+                        ambiguousEscapeStyle = AmbiguousEscapeStyle.SingleQuoted
+                    )
+                ).encodeToString(String.serializer(), "1.2")
+
+                it("returns the value serialized in the expected YAML form, escaping the float with single-quotes") {
+                    output shouldBe """'1.2'"""
+                }
+            }
         }
 
         describe("serializing enumeration values") {

--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlWritingTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlWritingTest.kt
@@ -261,8 +261,8 @@ class YamlWritingTest : DescribeSpec({
                 val output = Yaml(
                     configuration = YamlConfiguration(
                         singleLineStringStyle = SingleLineStringStyle.PlainExceptAmbiguous,
-                        ambiguousQuoteStyle = AmbiguousQuoteStyle.SingleQuoted
-                    )
+                        ambiguousQuoteStyle = AmbiguousQuoteStyle.SingleQuoted,
+                    ),
                 ).encodeToString(String.serializer(), "12")
 
                 it("returns the value serialized in the expected YAML form, escaping the integer with single-quotes") {
@@ -274,8 +274,8 @@ class YamlWritingTest : DescribeSpec({
                 val output = Yaml(
                     configuration = YamlConfiguration(
                         singleLineStringStyle = SingleLineStringStyle.PlainExceptAmbiguous,
-                        ambiguousQuoteStyle = AmbiguousQuoteStyle.SingleQuoted
-                    )
+                        ambiguousQuoteStyle = AmbiguousQuoteStyle.SingleQuoted,
+                    ),
                 ).encodeToString(String.serializer(), "true")
 
                 it("returns the value serialized in the expected YAML form, escaping the boolean with single-quotes") {
@@ -287,8 +287,8 @@ class YamlWritingTest : DescribeSpec({
                 val output = Yaml(
                     configuration = YamlConfiguration(
                         singleLineStringStyle = SingleLineStringStyle.PlainExceptAmbiguous,
-                        ambiguousQuoteStyle = AmbiguousQuoteStyle.SingleQuoted
-                    )
+                        ambiguousQuoteStyle = AmbiguousQuoteStyle.SingleQuoted,
+                    ),
                 ).encodeToString(String.serializer(), "1.2")
 
                 it("returns the value serialized in the expected YAML form, escaping the float with single-quotes") {

--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlWritingTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlWritingTest.kt
@@ -225,6 +225,38 @@ class YamlWritingTest : DescribeSpec({
                 }
             }
 
+            context("serializing an unambiguous numerical string using SingleLineStringStyle.PlainExceptAmbiguous") {
+                val output = Yaml(configuration = YamlConfiguration(singleLineStringStyle = SingleLineStringStyle.PlainExceptAmbiguous)).encodeToString(String.serializer(), "1.2.3")
+
+                it("returns the value serialized in the expected YAML form, without being escaped") {
+                    output shouldBe "1.2.3"
+                }
+            }
+
+            context("serializing an int using SingleLineStringStyle.PlainExceptAmbiguous") {
+                val output = Yaml(configuration = YamlConfiguration(singleLineStringStyle = SingleLineStringStyle.PlainExceptAmbiguous)).encodeToString(Int.serializer(), 123)
+
+                it("returns the value serialized in the expected YAML form, without being escaped") {
+                    output shouldBe "123"
+                }
+            }
+
+            context("serializing a float using SingleLineStringStyle.PlainExceptAmbiguous") {
+                val output = Yaml(configuration = YamlConfiguration(singleLineStringStyle = SingleLineStringStyle.PlainExceptAmbiguous)).encodeToString(Float.serializer(), 1.2f)
+
+                it("returns the value serialized in the expected YAML form, without being escaped") {
+                    output shouldBe "1.2"
+                }
+            }
+
+            context("serializing a boolean using SingleLineStringStyle.PlainExceptAmbiguous") {
+                val output = Yaml(configuration = YamlConfiguration(singleLineStringStyle = SingleLineStringStyle.PlainExceptAmbiguous)).encodeToString(Boolean.serializer(), true)
+
+                it("returns the value serialized in the expected YAML form, without being escaped") {
+                    output shouldBe "true"
+                }
+            }
+
             context("serializing a string with the value of an integer using SingleLineStringStyle.PlainExceptAmbiguous, escaping with single-quotes") {
                 val output = Yaml(
                     configuration = YamlConfiguration(

--- a/src/jvmMain/kotlin/com/charleskorn/kaml/YamlOutput.kt
+++ b/src/jvmMain/kotlin/com/charleskorn/kaml/YamlOutput.kt
@@ -88,6 +88,7 @@ internal class YamlOutput(
         } else {
             when {
                 value.contains('\n') -> emitQuotedScalar(value, configuration.multiLineStringStyle.scalarStyle)
+                configuration.singleLineStringStyle == SingleLineStringStyle.PlainExceptAmbiguous && value.isAmbiguous() -> emitQuotedScalar(value, configuration.ambiguousEscapeStyle.scalarStyle)
                 else -> emitQuotedScalar(value, configuration.singleLineStringStyle.scalarStyle)
             }
         }
@@ -180,6 +181,15 @@ internal class YamlOutput(
         return typeName
     }
 
+    private fun String.isAmbiguous(): Boolean {
+        return when {
+            toLongOrNull() != null -> true
+            toDoubleOrNull() != null -> true
+            toBooleanStrictOrNull() != null -> true
+            else -> false
+        }
+    }
+
     private val SequenceStyle.flowStyle: FlowStyle
         get() = when (this) {
             SequenceStyle.Block -> FlowStyle.BLOCK
@@ -199,6 +209,13 @@ internal class YamlOutput(
             SingleLineStringStyle.DoubleQuoted -> ScalarStyle.DOUBLE_QUOTED
             SingleLineStringStyle.SingleQuoted -> ScalarStyle.SINGLE_QUOTED
             SingleLineStringStyle.Plain -> ScalarStyle.PLAIN
+            SingleLineStringStyle.PlainExceptAmbiguous -> ScalarStyle.PLAIN
+        }
+
+    private val AmbiguousEscapeStyle.scalarStyle: ScalarStyle
+        get() = when (this) {
+            AmbiguousEscapeStyle.DoubleQuoted -> ScalarStyle.DOUBLE_QUOTED
+            AmbiguousEscapeStyle.SingleQuoted -> ScalarStyle.SINGLE_QUOTED
         }
 
     companion object {

--- a/src/jvmMain/kotlin/com/charleskorn/kaml/YamlOutput.kt
+++ b/src/jvmMain/kotlin/com/charleskorn/kaml/YamlOutput.kt
@@ -183,10 +183,16 @@ internal class YamlOutput(
 
     private fun String.isAmbiguous(): Boolean {
         return when {
-            toLongOrNull() != null -> true
+            isEmpty() -> true
+            toBigIntegerOrNull() != null -> true
+            startsWith("0x") && removePrefix("0x").toBigIntegerOrNull(16) != null -> true
+            startsWith("0o") && removePrefix("0o").toBigIntegerOrNull(8) != null -> true
             toDoubleOrNull() != null -> true
-            toBooleanStrictOrNull() != null -> true
-            else -> false
+            startsWith("#") -> true
+            else -> this in listOf(
+                "~", "-", ".inf", ".Inf", ".INF", "-.inf", "-.Inf", "-.INF", ".nan", ".NaN", ".NAN", "-.nan", "-.NaN",
+                "-.NAN", "null", "Null", "NULL", "true", "True", "TRUE", "false", "False", "FALSE"
+            )
         }
     }
 

--- a/src/jvmMain/kotlin/com/charleskorn/kaml/YamlOutput.kt
+++ b/src/jvmMain/kotlin/com/charleskorn/kaml/YamlOutput.kt
@@ -88,7 +88,7 @@ internal class YamlOutput(
         } else {
             when {
                 value.contains('\n') -> emitQuotedScalar(value, configuration.multiLineStringStyle.scalarStyle)
-                configuration.singleLineStringStyle == SingleLineStringStyle.PlainExceptAmbiguous && value.isAmbiguous() -> emitQuotedScalar(value, configuration.ambiguousEscapeStyle.scalarStyle)
+                configuration.singleLineStringStyle == SingleLineStringStyle.PlainExceptAmbiguous && value.isAmbiguous() -> emitQuotedScalar(value, configuration.ambiguousQuoteStyle.scalarStyle)
                 else -> emitQuotedScalar(value, configuration.singleLineStringStyle.scalarStyle)
             }
         }
@@ -218,10 +218,10 @@ internal class YamlOutput(
             SingleLineStringStyle.PlainExceptAmbiguous -> ScalarStyle.PLAIN
         }
 
-    private val AmbiguousEscapeStyle.scalarStyle: ScalarStyle
+    private val AmbiguousQuoteStyle.scalarStyle: ScalarStyle
         get() = when (this) {
-            AmbiguousEscapeStyle.DoubleQuoted -> ScalarStyle.DOUBLE_QUOTED
-            AmbiguousEscapeStyle.SingleQuoted -> ScalarStyle.SINGLE_QUOTED
+            AmbiguousQuoteStyle.DoubleQuoted -> ScalarStyle.DOUBLE_QUOTED
+            AmbiguousQuoteStyle.SingleQuoted -> ScalarStyle.SINGLE_QUOTED
         }
 
     companion object {

--- a/src/jvmMain/kotlin/com/charleskorn/kaml/YamlOutput.kt
+++ b/src/jvmMain/kotlin/com/charleskorn/kaml/YamlOutput.kt
@@ -185,8 +185,8 @@ internal class YamlOutput(
         return when {
             isEmpty() -> true
             toBigIntegerOrNull() != null -> true
-            startsWith("0x") && removePrefix("0x").toBigIntegerOrNull(16) != null -> true
-            startsWith("0o") && removePrefix("0o").toBigIntegerOrNull(8) != null -> true
+            startsWith("0x") -> true
+            startsWith("0o") -> true
             toDoubleOrNull() != null -> true
             startsWith("#") -> true
             else -> this in listOf(

--- a/src/jvmMain/kotlin/com/charleskorn/kaml/YamlOutput.kt
+++ b/src/jvmMain/kotlin/com/charleskorn/kaml/YamlOutput.kt
@@ -191,7 +191,7 @@ internal class YamlOutput(
             startsWith("#") -> true
             else -> this in listOf(
                 "~", "-", ".inf", ".Inf", ".INF", "-.inf", "-.Inf", "-.INF", ".nan", ".NaN", ".NAN", "-.nan", "-.NaN",
-                "-.NAN", "null", "Null", "NULL", "true", "True", "TRUE", "false", "False", "FALSE"
+                "-.NAN", "null", "Null", "NULL", "true", "True", "TRUE", "false", "False", "FALSE",
             )
         }
     }


### PR DESCRIPTION
This pull request adds SingleLineStringStyle.PlainExceptAmbiguous that escapes Strings that would be a different type if they were not a String. Resolves #367.

For example, when SingleLineStringStyle is set to PlainExceptAmbiguous, "12" will become "12" in Yaml, whereas Plain would have it be 12.

I have also added an extra configuration option of ambiguousEscapeStyle so the user can choose the escape style for when the string is ambiguous. If it is set to SingleQuoted, then the above example would be escaped like '12', rather than "12". This defaults to DoubleQuoted.

The private function String.isAmbiguous() deems a String as not a String if it was not a String by parsing it as a Long, Double and Boolean. If it is none of these, then it is not ambiguous and we can leave it as plain.

I have written 6 tests that test an Int, Float, and Boolean with each escape style.

It fallbacks to Plain for multiline strings.

I don't tend to contribute to libraries so let me know if I've missed anything or there's anything that can be done better :)