### PR TITLE
Remove unnecessary stdlib dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,8 +68,6 @@ kotlin {
 
         val jvmMain by getting {
             dependencies {
-                implementation(project.dependencies.platform("org.jetbrains.kotlin:kotlin-bom"))
-                implementation(kotlin("stdlib-jdk8"))
                 implementation("org.snakeyaml:snakeyaml-engine:2.6")
             }
         }


### PR DESCRIPTION
- Since Kotlin 1.4.0, the [stdlib dependency is longer required](https://kotlinlang.org/docs/gradle-configure-project.html#dependency-on-the-standard-library), and is added automatically according to the source set and Kotlin plugin version:
   - This means `stdlib-jvm` version 1.8.21 (the version of the Kotlin plugin) is automatically added anyway to the jvm source set.
- Since Kotlin 1.8.0, [stdlib-jdk8 has been merged into stdlib](https://kotlinlang.org/docs/whatsnew18.html#updated-jvm-compilation-target) because JDK 6 and JDK 7 are no longer targets.
- Version alignment is done automatically as above; the bom is only required if there are issues with this.