### PR TITLE
Replace kotlinOptions with compilerOptions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,8 @@ import com.charleskorn.kaml.build.configureSpotless
 import com.charleskorn.kaml.build.configureTesting
 import com.charleskorn.kaml.build.configureVersioning
 import com.charleskorn.kaml.build.configureWrapper
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     kotlin("multiplatform")
@@ -40,11 +42,6 @@ kotlin {
 
     jvm {
         withJava()
-        compilations.all {
-            kotlinOptions {
-                jvmTarget = "1.8"
-            }
-        }
     }
 
     sourceSets {
@@ -77,6 +74,12 @@ kotlin {
                 implementation("io.kotest:kotest-runner-junit5:5.6.1")
             }
         }
+    }
+}
+
+tasks.withType<KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_1_8)
     }
 }
 


### PR DESCRIPTION
In Kotlin 1.8.20, `kotlinOptions` was deprecated in favour of `compilerOptions`. This means there is type safety with specifying the JVM target now.

https://kotlinlang.org/docs/whatsnew1820.html
https://youtu.be/R1JpkpPzyBU?t=150