### PR TITLE
Use Java 17 in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3.12.0
         with:
-          java-version: 18
+          java-version: 17
           distribution: temurin
 
       - name: Cache Gradle


### PR DESCRIPTION
Java 18 is end-of-life. This pull request changes the build file to use Java 17 as that is the latest LTS release that has been built for Temurin. I would suggest upping this to Java 21 once Adoptium has created binaries for it and Kotlin supports Java 21.