### PR TITLE
Run workflow on Ubuntu, Windows and macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,11 @@ on: [push, pull_request]
 jobs:
   build:
     name: "Build, Test and Publish"
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     env:
       TERM: xterm-256color
       GPG_KEY_ID: 6D76AD03 # Run `gpg -K` to get this, take last eight characters

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
         env:
           GPG_KEY_RING: ${{ secrets.GPG_KEY_RING }} # Run `gpg --export-secret-keys "<key user name goes here>" | base64` to get this
           GPG_KEY_PASSPHRASE: ${{ secrets.GPG_KEY_PASSPHRASE }}
-        if: github.repository == 'charleskorn/kaml' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) && github.event_name == 'push'
+        if: github.repository == 'charleskorn/kaml' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) && github.event_name == 'push' && matrix.os == 'ubuntu-latest'
 
       - name: Publish snapshot
         run: ./gradlew publishSnapshot
@@ -68,7 +68,7 @@ jobs:
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
           GPG_KEY_RING: ${{ secrets.GPG_KEY_RING }} # Run `gpg --export-secret-keys "<key user name goes here>" | base64` to get this
           GPG_KEY_PASSPHRASE: ${{ secrets.GPG_KEY_PASSPHRASE }}
-        if: github.repository == 'charleskorn/kaml' && github.ref == 'refs/heads/main' && github.event_name == 'push'
+        if: github.repository == 'charleskorn/kaml' && github.ref == 'refs/heads/main' && github.event_name == 'push' && matrix.os == 'ubuntu-latest'
 
       - name: Publish release
         run: ./gradlew publishRelease
@@ -76,7 +76,7 @@ jobs:
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
           GPG_KEY_RING: ${{ secrets.GPG_KEY_RING }} # Run `gpg --export-secret-keys "<key user name goes here>" | base64` to get this
           GPG_KEY_PASSPHRASE: ${{ secrets.GPG_KEY_PASSPHRASE }}
-        if: github.repository == 'charleskorn/kaml' && startsWith(github.ref, 'refs/tags/') && github.event_name == 'push'
+        if: github.repository == 'charleskorn/kaml' && startsWith(github.ref, 'refs/tags/') && github.event_name == 'push' && matrix.os == 'ubuntu-latest'
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v0.1.15
@@ -86,7 +86,7 @@ jobs:
           draft: true # Update draft release with matching tag, if there is one.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: github.repository == 'charleskorn/kaml' && startsWith(github.ref, 'refs/tags/') && github.event_name == 'push'
+        if: github.repository == 'charleskorn/kaml' && startsWith(github.ref, 'refs/tags/') && github.event_name == 'push' && matrix.os == 'ubuntu-latest'
 
       - name: Clean up dependencies before caching
         if: steps.cache-packages.outputs.cache-hit != 'true'


### PR DESCRIPTION
This runs the build workflow on ubuntu-latest, windows-latest, and macos-latest. `fail-fast` is set to false so that if the build fails on one operating system the others will not stop.

The release steps will only run on Ubuntu as to not create and release the binaries multiple times. This will need to changed (along with some changes to the build file) in #458 after this PR so that native binaries can be built and released without causing duplicate binaries. Kotlin has [documentation](https://kotlinlang.org/docs/multiplatform-publish-lib.html#avoid-duplicate-publications) on this.