### PR TITLE
Fix typo in sealed class example

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,11 +156,11 @@ to reference the library in other build systems.
   sealed class Server {
     @SerialName("frontend")
     @Serializable
-    data class Frontend(val hostname: String)
+    data class Frontend(val hostname: String) : Server()
 
     @SerialName("backend")
     @Serializable
-    data class Backend(val database: String)
+    data class Backend(val database: String) : Server()
   }
 
   @Serializable


### PR DESCRIPTION
Fix up typo - `Backend` and `Frontend` should both be of type `Server`