### PR TITLE
Introduce PolymorphismStyle.None

### DIFF
--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlConfiguration.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlConfiguration.kt
@@ -35,7 +35,7 @@ package com.charleskorn.kaml
  * * [sequenceBlockIndent]: number of spaces to use as indentation for sequences, if [sequenceStyle] set to [SequenceStyle.Block]
  * * [allowAnchorsAndAliases]: set to true to allow anchors and aliases when decoding YAML (defaults to `false`)
  */
-public data class YamlConfiguration constructor(
+public data class YamlConfiguration(
     internal val encodeDefaults: Boolean = true,
     internal val strictMode: Boolean = true,
     internal val extensionDefinitionPrefix: String? = null,
@@ -55,6 +55,7 @@ public data class YamlConfiguration constructor(
 public enum class PolymorphismStyle {
     Tag,
     Property,
+    None,
 }
 
 public enum class SequenceStyle {

--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlInput.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlInput.kt
@@ -70,7 +70,10 @@ public sealed class YamlInput(
             }
 
             is YamlTaggedNode -> when {
-                descriptor.kind is PolymorphicKind && configuration.polymorphismStyle != PolymorphismStyle.Property -> {
+                descriptor.kind is PolymorphicKind && configuration.polymorphismStyle == PolymorphismStyle.None -> {
+                    throw IncorrectTypeException("Encountered a tagged polymorphic descriptor but PolymorphismStyle is 'None'", node.path)
+                }
+                descriptor.kind is PolymorphicKind && configuration.polymorphismStyle == PolymorphismStyle.Tag -> {
                     YamlPolymorphicInput(node.tag, node.path, node.innerNode, yaml, context, configuration)
                 }
                 else -> createFor(node.innerNode, yaml, context, configuration, descriptor)

--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlInput.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlInput.kt
@@ -63,7 +63,9 @@ public sealed class YamlInput(
                 is StructureKind.MAP -> YamlMapInput(node, yaml, context, configuration)
                 is SerialKind.CONTEXTUAL -> YamlContextualInput(node, yaml, context, configuration)
                 is PolymorphicKind -> when (configuration.polymorphismStyle) {
-                    PolymorphismStyle.Tag, PolymorphismStyle.None -> throw MissingTypeTagException(node.path)
+                    PolymorphismStyle.None ->
+                        throw IncorrectTypeException("Encountered a polymorphic map descriptor but PolymorphismStyle is 'None'", node.path)
+                    PolymorphismStyle.Tag, -> throw MissingTypeTagException(node.path)
                     PolymorphismStyle.Property -> createPolymorphicMapDeserializer(node, yaml, context, configuration)
                 }
                 else -> throw IncorrectTypeException("Expected ${descriptor.kind.friendlyDescription}, but got a map", node.path)

--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlInput.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlInput.kt
@@ -63,14 +63,16 @@ public sealed class YamlInput(
                 is StructureKind.MAP -> YamlMapInput(node, yaml, context, configuration)
                 is SerialKind.CONTEXTUAL -> YamlContextualInput(node, yaml, context, configuration)
                 is PolymorphicKind -> when (configuration.polymorphismStyle) {
-                    PolymorphismStyle.Tag -> throw MissingTypeTagException(node.path)
+                    PolymorphismStyle.Tag, PolymorphismStyle.None -> throw MissingTypeTagException(node.path)
                     PolymorphismStyle.Property -> createPolymorphicMapDeserializer(node, yaml, context, configuration)
                 }
                 else -> throw IncorrectTypeException("Expected ${descriptor.kind.friendlyDescription}, but got a map", node.path)
             }
 
             is YamlTaggedNode -> when {
-                descriptor.kind is PolymorphicKind && configuration.polymorphismStyle == PolymorphismStyle.Tag -> YamlPolymorphicInput(node.tag, node.path, node.innerNode, yaml, context, configuration)
+                descriptor.kind is PolymorphicKind && configuration.polymorphismStyle != PolymorphismStyle.Property -> {
+                    YamlPolymorphicInput(node.tag, node.path, node.innerNode, yaml, context, configuration)
+                }
                 else -> createFor(node.innerNode, yaml, context, configuration, descriptor)
             }
         }

--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlInput.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlInput.kt
@@ -65,7 +65,7 @@ public sealed class YamlInput(
                 is PolymorphicKind -> when (configuration.polymorphismStyle) {
                     PolymorphismStyle.None ->
                         throw IncorrectTypeException("Encountered a polymorphic map descriptor but PolymorphismStyle is 'None'", node.path)
-                    PolymorphismStyle.Tag, -> throw MissingTypeTagException(node.path)
+                    PolymorphismStyle.Tag -> throw MissingTypeTagException(node.path)
                     PolymorphismStyle.Property -> createPolymorphicMapDeserializer(node, yaml, context, configuration)
                 }
                 else -> throw IncorrectTypeException("Expected ${descriptor.kind.friendlyDescription}, but got a map", node.path)

--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlReadingTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlReadingTest.kt
@@ -2033,7 +2033,7 @@ class YamlReadingTest : DescribeSpec({
             describe("given polymorphic inputs when PolymorphismStyle.None is used") {
                 val polymorphicYaml = Yaml(serializersModule = polymorphicModule, configuration = YamlConfiguration(polymorphismStyle = PolymorphismStyle.None))
 
-                context("given tagged input should fail") {
+                context("given tagged input") {
                     val input = """
                         !<sealedString>
                         value: "asdfg"

--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlReadingTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlReadingTest.kt
@@ -2052,7 +2052,7 @@ class YamlReadingTest : DescribeSpec({
                         }
                     }
                 }
-                context("given property polymorphism input should fail") {
+                context("given property polymorphism input") {
                     val input = """
                         type: sealedString
                         value: "asdfg"

--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlReadingTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlReadingTest.kt
@@ -2029,6 +2029,49 @@ class YamlReadingTest : DescribeSpec({
                     }
                 }
             }
+
+            describe("given polymorphic inputs when PolymorphismStyle.None is used") {
+                val polymorphicYaml = Yaml(serializersModule = polymorphicModule, configuration = YamlConfiguration(polymorphismStyle = PolymorphismStyle.None))
+
+                context("given tagged input should fail") {
+                    val input = """
+                        !<sealedString>
+                        value: "asdfg"
+                    """.trimIndent()
+
+                    context("parsing that input") {
+                        it("throws an appropriate exception") {
+                            val exception = shouldThrow<IncorrectTypeException> { polymorphicYaml.decodeFromString(TestSealedStructure.serializer(), input) }
+
+                            exception.asClue {
+                                it.message shouldBe "Encountered a tagged polymorphic descriptor but PolymorphismStyle is 'None'"
+                                it.line shouldBe 1
+                                it.column shouldBe 1
+                                it.path shouldBe YamlPath.root
+                            }
+                        }
+                    }
+                }
+                context("given property polymorphism input should fail") {
+                    val input = """
+                        type: sealedString
+                        value: "asdfg"
+                    """.trimIndent()
+
+                    context("parsing that input") {
+                        it("throws an appropriate exception") {
+                            val exception = shouldThrow<IncorrectTypeException> { polymorphicYaml.decodeFromString(TestSealedStructure.serializer(), input) }
+
+                            exception.asClue {
+                                it.message shouldBe "Encountered a polymorphic map descriptor but PolymorphismStyle is 'None'"
+                                it.line shouldBe 1
+                                it.column shouldBe 1
+                                it.path shouldBe YamlPath.root
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         describe("parsing values with a dynamically installed serializer") {

--- a/src/jsMain/kotlin/com/charleskorn/kaml/YamlOutput.kt
+++ b/src/jsMain/kotlin/com/charleskorn/kaml/YamlOutput.kt
@@ -130,6 +130,9 @@ internal class YamlOutput(
                             emitQuotedScalar(typeName, SingleLineStringStyle.DoubleQuoted.scalarStyle)
                         }
                     }
+                    PolymorphismStyle.None -> {
+                        emitter.emit(MappingStartEvent(null, null, true, FlowStyle.BLOCK))
+                    }
                 }
             }
             else -> {

--- a/src/jvmMain/kotlin/com/charleskorn/kaml/YamlOutput.kt
+++ b/src/jvmMain/kotlin/com/charleskorn/kaml/YamlOutput.kt
@@ -131,6 +131,9 @@ internal class YamlOutput(
                             emitQuotedScalar(typeName.get(), SingleLineStringStyle.DoubleQuoted.scalarStyle)
                         }
                     }
+                    PolymorphismStyle.None -> {
+                        emitter.emit(MappingStartEvent(Optional.empty(), Optional.empty(), true, FlowStyle.BLOCK))
+                    }
                 }
             }
             else -> {


### PR DESCRIPTION
This implements #378 by introducing a new `None` style that omits the tag/property entirely from the output yaml.

Note this is asymmetric and reads are treated the same as `Tag` as reads require a tag.

I added a few tests to JvmYamlWritingTest for both this case and some added coverage for the existing two cases as well.