### PR TITLE
Enable Wasm tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,20 +63,8 @@ kotlin {
 
     wasmJs {
         binaries.library()
-        browser {
-            testTask {
-                // TODO: enable once the tests work with Kotlin/Wasm.
-                // See https://youtrack.jetbrains.com/issue/KT-68950/
-                enabled = false
-            }
-        }
-        nodejs {
-            testTask {
-                // TODO: enable once the tests work with Kotlin/Wasm.
-                // See https://youtrack.jetbrains.com/issue/KT-68950/
-                enabled = false
-            }
-        }
+        browser()
+        nodejs()
     }
 
     sourceSets {

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@colors/colors@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
+  integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
+
 "@discoveryjs/json-ext@^0.5.0":
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
@@ -89,6 +94,11 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
+"@socket.io/component-emitter@~3.1.0":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz#821f8442f4175d8f0467b9daf26e3a18e2d02af2"
+  integrity sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==
+
 "@types/body-parser@*":
   version "1.19.5"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.5.tgz#04ce9a3b677dc8bd681a17da1ab9835dc9d3ede4"
@@ -116,6 +126,18 @@
   version "3.4.38"
   resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.38.tgz#5ba7f3bc4fbbdeaff8dded952e5ff2cc53f8d858"
   integrity sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==
+  dependencies:
+    "@types/node" "*"
+
+"@types/cookie@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.1.tgz#bfd02c1f2224567676c1545199f87c3a861d878d"
+  integrity sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==
+
+"@types/cors@^2.8.12":
+  version "2.8.17"
+  resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.17.tgz#5d718a5e494a8166f569d986794e49c48b216b2b"
+  integrity sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==
   dependencies:
     "@types/node" "*"
 
@@ -189,7 +211,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*":
+"@types/node@*", "@types/node@>=10.0.0":
   version "20.14.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.14.2.tgz#a5f4d2bcb4b6a87bffcaa717718c5a0f208f4a18"
   integrity sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==
@@ -409,9 +431,9 @@ acorn-import-assertions@^1.9.0:
   integrity sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==
 
 acorn@^8.7.1, acorn@^8.8.2:
-  version "8.11.3"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.11.3.tgz#71e0b14e13a4ec160724b38fb7b0f233b1b81d7a"
-  integrity sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==
+  version "8.12.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.12.0.tgz#1627bfa2e058148036133b8d9b51a700663c294c"
+  integrity sha512-RTvkC4w+KNXrM39/lWCUaG0IbRkWdCv7W/IOW9oU6SawyxulvkQy5HQPVTKxEjczcUvapcrw3cFx/60VN/NRNw==
 
 ajv-formats@^2.1.1:
   version "2.1.1"
@@ -452,6 +474,11 @@ ajv@^8.0.0, ajv@^8.9.0:
     require-from-string "^2.0.2"
     uri-js "^4.4.1"
 
+ansi-colors@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
+  integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
+
 ansi-html-community@^0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz#69fbc4d6ccbe383f9736934ae34c3f8290f1bf41"
@@ -467,7 +494,7 @@ ansi-regex@^6.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
   integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
 
-ansi-styles@^4.0.0:
+ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
@@ -487,6 +514,11 @@ anymatch@~3.1.2:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
 array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
@@ -496,6 +528,11 @@ balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+
+base64id@2.0.0, base64id@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/base64id/-/base64id-2.0.0.tgz#2770ac6bc47d312af97a8bf9a634342e0cd25cb6"
+  integrity sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==
 
 batch@0.6.1:
   version "0.6.1"
@@ -507,7 +544,7 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.3.0.tgz#f6e14a97858d327252200242d4ccfe522c445522"
   integrity sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==
 
-body-parser@1.20.2:
+body-parser@1.20.2, body-parser@^1.19.0:
   version "1.20.2"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.2.tgz#6feb0e21c4724d06de7ff38da36dad4f57a747fd"
   integrity sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==
@@ -533,6 +570,14 @@ bonjour-service@^1.2.1:
     fast-deep-equal "^3.1.3"
     multicast-dns "^7.2.5"
 
+brace-expansion@^1.1.7:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
+  dependencies:
+    balanced-match "^1.0.0"
+    concat-map "0.0.1"
+
 brace-expansion@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
@@ -540,22 +585,27 @@ brace-expansion@^2.0.1:
   dependencies:
     balanced-match "^1.0.0"
 
-braces@^3.0.3, braces@~3.0.2:
+braces@^3.0.2, braces@^3.0.3, braces@~3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
   integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
   dependencies:
     fill-range "^7.1.1"
 
+browser-stdout@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
+  integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
+
 browserslist@^4.21.10:
-  version "4.23.0"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.23.0.tgz#8f3acc2bbe73af7213399430890f86c63a5674ab"
-  integrity sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==
+  version "4.23.1"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.23.1.tgz#ce4af0534b3d37db5c1a4ca98b9080f985041e96"
+  integrity sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==
   dependencies:
-    caniuse-lite "^1.0.30001587"
-    electron-to-chromium "^1.4.668"
+    caniuse-lite "^1.0.30001629"
+    electron-to-chromium "^1.4.796"
     node-releases "^2.0.14"
-    update-browserslist-db "^1.0.13"
+    update-browserslist-db "^1.0.16"
 
 buffer-from@^1.0.0:
   version "1.1.2"
@@ -590,12 +640,40 @@ call-bind@^1.0.7:
     get-intrinsic "^1.2.4"
     set-function-length "^1.2.1"
 
-caniuse-lite@^1.0.30001587:
-  version "1.0.30001629"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001629.tgz#907a36f4669031bd8a1a8dbc2fa08b29e0db297e"
-  integrity sha512-c3dl911slnQhmxUIT4HhYzT7wnBK/XYpGnYLOj4nJBaRiw52Ibe7YxlDaAeRECvA786zCuExhxIUJ2K7nHMrBw==
+camelcase@^6.0.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
+  integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
-chokidar@^3.6.0:
+caniuse-lite@^1.0.30001629:
+  version "1.0.30001636"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001636.tgz#b15f52d2bdb95fad32c2f53c0b68032b85188a78"
+  integrity sha512-bMg2vmr8XBsbL6Lr0UHXy/21m84FTxDLWn2FSqMd5PrlbMxwJlQnC2YWYxVgp66PZE+BBNF2jYQUBKCo1FDeZg==
+
+chalk@^4.1.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
+chokidar@3.5.3:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
+  integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
+chokidar@^3.5.1, chokidar@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
   integrity sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==
@@ -614,6 +692,15 @@ chrome-trace-event@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz#05bffd7ff928465093314708c93bdfa9bd1f0f5b"
   integrity sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==
+
+cliui@^7.0.2:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
+  integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
 
 clone-deep@^4.0.1:
   version "4.0.1"
@@ -671,10 +758,25 @@ compression@^1.7.4:
     safe-buffer "5.1.2"
     vary "~1.1.2"
 
+concat-map@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+  integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
+
 connect-history-api-fallback@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz#647264845251a0daf25b97ce87834cace0f5f1c8"
   integrity sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==
+
+connect@^3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/connect/-/connect-3.7.0.tgz#5d49348910caa5e07a01800b030d0c35f20484f8"
+  integrity sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==
+  dependencies:
+    debug "2.6.9"
+    finalhandler "1.1.2"
+    parseurl "~1.3.3"
+    utils-merge "1.0.1"
 
 content-disposition@0.5.4:
   version "0.5.4"
@@ -698,10 +800,23 @@ cookie@0.6.0:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.6.0.tgz#2798b04b071b0ecbff0dbb62a505a8efa4e19051"
   integrity sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==
 
+cookie@~0.4.1:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
+  integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
+
 core-util-is@~1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
+
+cors@~2.8.5:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
+  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
+  dependencies:
+    object-assign "^4"
+    vary "^1"
 
 cross-spawn@^7.0.0, cross-spawn@^7.0.3:
   version "7.0.3"
@@ -712,6 +827,16 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+custom-event@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/custom-event/-/custom-event-1.0.1.tgz#5d02a46850adf1b4a317946a3928fccb5bfd0425"
+  integrity sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg==
+
+date-format@^4.0.14:
+  version "4.0.14"
+  resolved "https://registry.yarnpkg.com/date-format/-/date-format-4.0.14.tgz#7a8e584434fb169a521c8b7aa481f355810d9400"
+  integrity sha512-39BOQLs9ZjKh0/patS9nrT8wc3ioX3/eA/zgbKNopnF2wCqJEoxywwwElATYvRsXdnOxA/OQeQoFZ3rFjVajhg==
+
 debug@2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -719,12 +844,24 @@ debug@2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@^4.1.0:
+debug@4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
+
+debug@^4.1.0, debug@^4.3.4, debug@~4.3.1, debug@~4.3.2, debug@~4.3.4:
   version "4.3.5"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.5.tgz#e83444eceb9fedd4a1da56d671ae2446a01a6e1e"
   integrity sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==
   dependencies:
     ms "2.1.2"
+
+decamelize@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-4.0.0.tgz#aa472d7bf660eb15f3494efd531cab7f2a709837"
+  integrity sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==
 
 default-browser-id@^5.0.0:
   version "5.0.0"
@@ -780,12 +917,32 @@ detect-node@^2.0.4:
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
   integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
 
+di@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/di/-/di-0.0.1.tgz#806649326ceaa7caa3306d75d985ea2748ba913c"
+  integrity sha512-uJaamHkagcZtHPqCIHZxnFrXlunQXgBOsZSUOWwFw31QJCAbyTBoHMW75YOTur5ZNx8pIeAKgf6GWIgaqqiLhA==
+
+diff@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
+  integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
+
 dns-packet@^5.2.2:
   version "5.6.1"
   resolved "https://registry.yarnpkg.com/dns-packet/-/dns-packet-5.6.1.tgz#ae888ad425a9d1478a0674256ab866de1012cf2f"
   integrity sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==
   dependencies:
     "@leichtgewicht/ip-codec" "^2.0.1"
+
+dom-serialize@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/dom-serialize/-/dom-serialize-2.2.1.tgz#562ae8999f44be5ea3076f5419dcd59eb43ac95b"
+  integrity sha512-Yra4DbvoW7/Z6LBN560ZwXMjoNOSAN2wRsKFGc4iBeso+mpIA6qj1vfdf9HpMaKAqG6wXTy+1SYEzmNpKXOSsQ==
+  dependencies:
+    custom-event "~1.0.0"
+    ent "~2.2.0"
+    extend "^3.0.0"
+    void-elements "^2.0.0"
 
 eastasianwidth@^0.2.0:
   version "0.2.0"
@@ -797,10 +954,10 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
-electron-to-chromium@^1.4.668:
-  version "1.4.794"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.794.tgz#cca7762998f6c42517770666e272f52a53c08605"
-  integrity sha512-6FApLtsYhDCY0Vglq3AptsdxQ+PJLc6AxlAM0HjEihUAiOPPbkASEsq9gtxUeZY9o0sJIEa3WnF0vVH4VT4iug==
+electron-to-chromium@^1.4.796:
+  version "1.4.803"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.803.tgz#cf55808a5ee12e2a2778bbe8cdc941ef87c2093b"
+  integrity sha512-61H9mLzGOCLLVsnLiRzCbc63uldP0AniRYPV3hbGVtONA1pI7qSGILdbofR7A8TMbOypDocEAjH/e+9k1QIe3g==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -817,6 +974,27 @@ encodeurl@~1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==
 
+engine.io-parser@~5.2.1:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-5.2.2.tgz#37b48e2d23116919a3453738c5720455e64e1c49"
+  integrity sha512-RcyUFKA93/CXH20l4SoVvzZfrSDMOTUS3bWVpTt2FuFP+XYrL8i8oonHP7WInRyVHXh0n/ORtoeiE1os+8qkSw==
+
+engine.io@~6.5.2:
+  version "6.5.4"
+  resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-6.5.4.tgz#6822debf324e781add2254e912f8568508850cdc"
+  integrity sha512-KdVSDKhVKyOi+r5uEabrDLZw2qXStVvCsEB/LN3mw4WFi6Gx50jTyuxYVCwAAC0U46FdnzP/ScKRBTXb/NiEOg==
+  dependencies:
+    "@types/cookie" "^0.4.1"
+    "@types/cors" "^2.8.12"
+    "@types/node" ">=10.0.0"
+    accepts "~1.3.4"
+    base64id "2.0.0"
+    cookie "~0.4.1"
+    cors "~2.8.5"
+    debug "~4.3.1"
+    engine.io-parser "~5.2.1"
+    ws "~8.11.0"
+
 enhanced-resolve@^5.16.0:
   version "5.17.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.17.0.tgz#d037603789dd9555b89aaec7eb78845c49089bc5"
@@ -824,6 +1002,11 @@ enhanced-resolve@^5.16.0:
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
+
+ent@~2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/ent/-/ent-2.2.0.tgz#e964219325a21d05f44466a2f686ed6ce5f5dd1d"
+  integrity sha512-GHrMyVZQWvTIdDtpiEXdHZnFQKzeO09apj8Cbl4pKWy4i0Oprcq17usfDt5aO63swf0JOeMWjWQE/LzgSRuWpA==
 
 envinfo@^7.7.3:
   version "7.13.0"
@@ -847,7 +1030,7 @@ es-module-lexer@^1.2.1:
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.5.3.tgz#25969419de9c0b1fbe54279789023e8a9a788412"
   integrity sha512-i1gCgmR9dCl6Vil6UKPI/trA69s08g/syhiDK9TG0Nf1RJjjFI+AzoWW7sPufzkgYAn861skuCwJa0pIIHYxvg==
 
-escalade@^3.1.2:
+escalade@^3.1.1, escalade@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.2.tgz#54076e9ab29ea5bf3d8f1ed62acffbb88272df27"
   integrity sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==
@@ -856,6 +1039,11 @@ escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
+
+escape-string-regexp@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
+  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
 eslint-scope@5.1.1:
   version "5.1.1"
@@ -949,6 +1137,11 @@ express@^4.17.3:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
+extend@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -978,6 +1171,19 @@ fill-range@^7.1.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+finalhandler@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.2.tgz#b7e7d000ffd11938d0fdb053506f6ebabe9f587d"
+  integrity sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==
+  dependencies:
+    debug "2.6.9"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    on-finished "~2.3.0"
+    parseurl "~1.3.3"
+    statuses "~1.5.0"
+    unpipe "~1.0.0"
+
 finalhandler@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.2.0.tgz#7d23fe5731b207b4640e4fcd00aec1f9207a7b32"
@@ -990,6 +1196,14 @@ finalhandler@1.2.0:
     parseurl "~1.3.3"
     statuses "2.0.1"
     unpipe "~1.0.0"
+
+find-up@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
+  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
+  dependencies:
+    locate-path "^6.0.0"
+    path-exists "^4.0.0"
 
 find-up@^4.0.0:
   version "4.1.0"
@@ -1004,15 +1218,20 @@ flat@^5.0.2:
   resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
   integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
 
+flatted@^3.2.7:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.1.tgz#21db470729a6734d4997002f439cb308987f567a"
+  integrity sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==
+
 follow-redirects@^1.0.0:
   version "1.15.6"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
   integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
 
 foreground-child@^3.1.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.1.1.tgz#1d173e776d75d2772fed08efe4a0de1ea1b12d0d"
-  integrity sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.2.1.tgz#767004ccf3a5b30df39bed90718bab43fe0a59f7"
+  integrity sha512-PXUUyLqrR2XCWICfv6ukppP96sdFwWbNEnfEMt7jNsISjMsvaLNinAHNDYyvkyU+SZG2BTSbT5NjG+vZslfGTA==
   dependencies:
     cross-spawn "^7.0.0"
     signal-exit "^4.0.1"
@@ -1032,6 +1251,20 @@ fresh@0.5.2:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==
 
+fs-extra@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
+  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
+fs.realpath@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+  integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+
 fsevents@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
@@ -1041,6 +1274,11 @@ function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
+
+get-caller-file@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
+  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
 get-intrinsic@^1.1.3, get-intrinsic@^1.2.4:
   version "1.2.4"
@@ -1070,6 +1308,17 @@ glob-to-regexp@^0.4.1:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
+glob@8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
+  integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^5.0.1"
+    once "^1.3.0"
+
 glob@^10.3.7:
   version "10.4.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-10.4.1.tgz#0cfb01ab6a6b438177bfe6a58e2576f6efe909c2"
@@ -1081,6 +1330,18 @@ glob@^10.3.7:
     minipass "^7.1.2"
     path-scurry "^1.11.1"
 
+glob@^7.1.3, glob@^7.1.7:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
+  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.1.1"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 gopd@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
@@ -1088,7 +1349,7 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
-graceful-fs@^4.1.2, graceful-fs@^4.2.11, graceful-fs@^4.2.4, graceful-fs@^4.2.6:
+graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.10, graceful-fs@^4.2.11, graceful-fs@^4.2.4, graceful-fs@^4.2.6:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -1126,6 +1387,11 @@ hasown@^2.0.0:
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
   dependencies:
     function-bind "^1.1.2"
+
+he@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
 hpack.js@^2.1.6:
   version "2.1.6"
@@ -1225,15 +1491,23 @@ import-local@^3.0.2:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
 
+inflight@^1.0.4:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+  integrity sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==
+  dependencies:
+    once "^1.3.0"
+    wrappy "1"
+
+inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
 inherits@2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==
-
-inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.3:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
-  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
 interpret@^3.1.1:
   version "3.1.1"
@@ -1303,6 +1577,11 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
+is-plain-obj@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
+  integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
+
 is-plain-obj@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-3.0.0.tgz#af6f2ea14ac5a646183a5bbdb5baabbc156ad9d7"
@@ -1320,6 +1599,11 @@ is-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
   integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
 
+is-unicode-supported@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
+  integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
+
 is-wsl@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-3.1.0.tgz#e1c657e39c10090afcbedec61720f6b924c3cbd2"
@@ -1331,6 +1615,11 @@ isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==
+
+isbinaryfile@^4.0.8:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-4.0.10.tgz#0c5b5e30c2557a2f06febd37b7322946aaee42b3"
+  integrity sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -1360,6 +1649,13 @@ jest-worker@^27.4.5:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
+js-yaml@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
+
 json-parse-even-better-errors@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
@@ -1375,15 +1671,82 @@ json-schema-traverse@^1.0.0:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
   integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  integrity sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
+karma-chrome-launcher@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/karma-chrome-launcher/-/karma-chrome-launcher-3.2.0.tgz#eb9c95024f2d6dfbb3748d3415ac9b381906b9a9"
+  integrity sha512-rE9RkUPI7I9mAxByQWkGJFXfFD6lE4gC5nPuZdobf/QdTEJI6EU4yIay/cfU/xV4ZxlM5JiTv7zWYgA64NpS5Q==
+  dependencies:
+    which "^1.2.1"
+
+karma-mocha@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/karma-mocha/-/karma-mocha-2.0.1.tgz#4b0254a18dfee71bdbe6188d9a6861bf86b0cd7d"
+  integrity sha512-Tzd5HBjm8his2OA4bouAsATYEpZrp9vC7z5E5j4C5Of5Rrs1jY67RAwXNcVmd/Bnk1wgvQRou0zGVLey44G4tQ==
+  dependencies:
+    minimist "^1.2.3"
+
+karma-sourcemap-loader@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/karma-sourcemap-loader/-/karma-sourcemap-loader-0.4.0.tgz#b01d73f8f688f533bcc8f5d273d43458e13b5488"
+  integrity sha512-xCRL3/pmhAYF3I6qOrcn0uhbQevitc2DERMPH82FMnG+4WReoGcGFZb1pURf2a5apyrOHRdvD+O6K7NljqKHyA==
+  dependencies:
+    graceful-fs "^4.2.10"
+
+karma-webpack@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/karma-webpack/-/karma-webpack-5.0.1.tgz#4eafd31bbe684a747a6e8f3e4ad373e53979ced4"
+  integrity sha512-oo38O+P3W2mSPCSUrQdySSPv1LvPpXP+f+bBimNomS5sW+1V4SuhCuW8TfJzV+rDv921w2fDSDw0xJbPe6U+kQ==
+  dependencies:
+    glob "^7.1.3"
+    minimatch "^9.0.3"
+    webpack-merge "^4.1.5"
+
+karma@6.4.3:
+  version "6.4.3"
+  resolved "https://registry.yarnpkg.com/karma/-/karma-6.4.3.tgz#763e500f99597218bbb536de1a14acc4ceea7ce8"
+  integrity sha512-LuucC/RE92tJ8mlCwqEoRWXP38UMAqpnq98vktmS9SznSoUPPUJQbc91dHcxcunROvfQjdORVA/YFviH+Xci9Q==
+  dependencies:
+    "@colors/colors" "1.5.0"
+    body-parser "^1.19.0"
+    braces "^3.0.2"
+    chokidar "^3.5.1"
+    connect "^3.7.0"
+    di "^0.0.1"
+    dom-serialize "^2.2.1"
+    glob "^7.1.7"
+    graceful-fs "^4.2.6"
+    http-proxy "^1.18.1"
+    isbinaryfile "^4.0.8"
+    lodash "^4.17.21"
+    log4js "^6.4.1"
+    mime "^2.5.2"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.5"
+    qjobs "^1.2.0"
+    range-parser "^1.2.1"
+    rimraf "^3.0.2"
+    socket.io "^4.7.2"
+    source-map "^0.6.1"
+    tmp "^0.2.1"
+    ua-parser-js "^0.7.30"
+    yargs "^16.1.1"
+
 kind-of@^6.0.2:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
 launch-editor@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/launch-editor/-/launch-editor-2.6.1.tgz#f259c9ef95cbc9425620bbbd14b468fcdb4ffe3c"
-  integrity sha512-eB/uXmFVpY4zezmGp5XtU21kwo7GBbKB+EQ+UZeWtGb9yAM5xt/Evk+lYH3eRNAtId+ej4u7TYPFZ07w4s7rRw==
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/launch-editor/-/launch-editor-2.7.0.tgz#53ba12b3eb131edefee99acaef7850c40272273f"
+  integrity sha512-KAc66u6LxWL8MifQ94oG3YGKYWDwz/Gi0T15lN//GaQoZe08vQGFJxrXkPAeu50UXgvJPPaRKVGuP1TRUm/aHQ==
   dependencies:
     picocolors "^1.0.0"
     shell-quote "^1.8.1"
@@ -1400,6 +1763,37 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+locate-path@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
+  integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
+  dependencies:
+    p-locate "^5.0.0"
+
+lodash@^4.17.15, lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+log-symbols@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.1.0.tgz#3fbdbb95b4683ac9fc785111e792e558d4abd503"
+  integrity sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==
+  dependencies:
+    chalk "^4.1.0"
+    is-unicode-supported "^0.1.0"
+
+log4js@^6.4.1:
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/log4js/-/log4js-6.9.1.tgz#aba5a3ff4e7872ae34f8b4c533706753709e38b6"
+  integrity sha512-1somDdy9sChrr9/f4UlzhdaGfDR2c/SaD2a4T7qEkG4jTS57/B3qmnjLYePwQ8cqWnUHZI0iAKxMBpCZICiZ2g==
+  dependencies:
+    date-format "^4.0.14"
+    debug "^4.3.4"
+    flatted "^3.2.7"
+    rfdc "^1.3.0"
+    streamroller "^3.1.5"
+
 lru-cache@^10.2.0:
   version "10.2.2"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.2.2.tgz#48206bc114c1252940c41b25b41af5b545aca878"
@@ -1411,13 +1805,13 @@ media-typer@0.3.0:
   integrity sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==
 
 memfs@^4.6.0:
-  version "4.9.2"
-  resolved "https://registry.yarnpkg.com/memfs/-/memfs-4.9.2.tgz#42e7b48207268dad8c9c48ea5d4952c5d3840433"
-  integrity sha512-f16coDZlTG1jskq3mxarwB+fGRrd0uXWt+o1WIhRfOwbXQZqUDsTVxQBFK9JjRQHblg8eAG2JSbprDXKjc7ijQ==
+  version "4.9.3"
+  resolved "https://registry.yarnpkg.com/memfs/-/memfs-4.9.3.tgz#41a3218065fe3911d9eba836250c8f4e43f816bc"
+  integrity sha512-bsYSSnirtYTWi1+OPMFb0M048evMKyUYe0EbtuGQgq6BVQM1g1W8/KIUJCCvjgI/El0j6Q4WsmMiBwLUBSw8LA==
   dependencies:
     "@jsonjoy.com/json-pack" "^1.0.3"
     "@jsonjoy.com/util" "^1.1.2"
-    sonic-forest "^1.0.0"
+    tree-dump "^1.0.1"
     tslib "^2.0.0"
 
 merge-descriptors@1.0.1:
@@ -1460,6 +1854,11 @@ mime@1.6.0:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
+mime@^2.5.2:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367"
+  integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
+
 mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
@@ -1470,17 +1869,76 @@ minimalistic-assert@^1.0.0:
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
   integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
 
-minimatch@^9.0.4:
+minimatch@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.0.1.tgz#fb9022f7528125187c92bd9e9b6366be1cf3415b"
+  integrity sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==
+  dependencies:
+    brace-expansion "^2.0.1"
+
+minimatch@^3.0.4, minimatch@^3.1.1:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  dependencies:
+    brace-expansion "^1.1.7"
+
+minimatch@^5.0.1:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
+  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
+  dependencies:
+    brace-expansion "^2.0.1"
+
+minimatch@^9.0.3, minimatch@^9.0.4:
   version "9.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.4.tgz#8e49c731d1749cbec05050ee5145147b32496a51"
   integrity sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==
   dependencies:
     brace-expansion "^2.0.1"
 
+minimist@^1.2.3, minimist@^1.2.6:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
+
 "minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.2.tgz#93a9626ce5e5e66bd4db86849e7515e92340a707"
   integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
+
+mkdirp@^0.5.5:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
+  integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
+  dependencies:
+    minimist "^1.2.6"
+
+mocha@10.3.0:
+  version "10.3.0"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.3.0.tgz#0e185c49e6dccf582035c05fa91084a4ff6e3fe9"
+  integrity sha512-uF2XJs+7xSLsrmIvn37i/wnc91nw7XjOQB8ccyx5aEgdnohr7n+rEiZP23WkCYHjilR6+EboEnbq/ZQDz4LSbg==
+  dependencies:
+    ansi-colors "4.1.1"
+    browser-stdout "1.3.1"
+    chokidar "3.5.3"
+    debug "4.3.4"
+    diff "5.0.0"
+    escape-string-regexp "4.0.0"
+    find-up "5.0.0"
+    glob "8.1.0"
+    he "1.2.0"
+    js-yaml "4.1.0"
+    log-symbols "4.1.0"
+    minimatch "5.0.1"
+    ms "2.1.3"
+    serialize-javascript "6.0.0"
+    strip-json-comments "3.1.1"
+    supports-color "8.1.1"
+    workerpool "6.2.1"
+    yargs "16.2.0"
+    yargs-parser "20.2.4"
+    yargs-unparser "2.0.0"
 
 ms@2.0.0:
   version "2.0.0"
@@ -1537,6 +1995,11 @@ npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
+object-assign@^4:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
+
 object-inspect@^1.13.1:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.1.tgz#b96c6109324ccfef6b12216a956ca4dc2ff94bc2"
@@ -1554,10 +2017,24 @@ on-finished@2.4.1, on-finished@^2.4.1:
   dependencies:
     ee-first "1.1.1"
 
+on-finished@~2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
+  integrity sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==
+  dependencies:
+    ee-first "1.1.1"
+
 on-headers@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.2.tgz#772b0ae6aaa525c399e489adfad90c403eb3c28f"
   integrity sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==
+
+once@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
+  dependencies:
+    wrappy "1"
 
 onetime@^5.1.2:
   version "5.1.2"
@@ -1583,12 +2060,26 @@ p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
+p-limit@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
+  integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
+  dependencies:
+    yocto-queue "^0.1.0"
+
 p-locate@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-4.1.0.tgz#a3428bb7088b3a60292f66919278b7c297ad4f07"
   integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
   dependencies:
     p-limit "^2.2.0"
+
+p-locate@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
+  integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
+  dependencies:
+    p-limit "^3.0.2"
 
 p-retry@^6.2.0:
   version "6.2.0"
@@ -1613,6 +2104,11 @@ path-exists@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
+
+path-is-absolute@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+  integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
 
 path-key@^3.0.0, path-key@^3.1.0:
   version "3.1.1"
@@ -1671,6 +2167,11 @@ punycode@^2.1.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
+
+qjobs@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/qjobs/-/qjobs-1.2.0.tgz#c45e9c61800bd087ef88d7e256423bdd49e5d071"
+  integrity sha512-8YOJEHtxpySA3fFDyCRxA+UUV+fA+rTWnuWvylOK/NCjhY+b4ocCtmu8TtsWb+mYeU+GCHf/S66KZF/AsteKHg==
 
 qs@6.11.0:
   version "6.11.0"
@@ -1737,6 +2238,11 @@ rechoir@^0.8.0:
   dependencies:
     resolve "^1.20.0"
 
+require-directory@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
+  integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
+
 require-from-string@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
@@ -1772,6 +2278,18 @@ retry@^0.13.1:
   version "0.13.1"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
   integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
+
+rfdc@^1.3.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.4.1.tgz#778f76c4fb731d93414e8f925fbecf64cce7f6ca"
+  integrity sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==
+
+rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
 
 rimraf@^5.0.5:
   version "5.0.7"
@@ -1850,6 +2368,13 @@ send@0.18.0:
     on-finished "2.4.1"
     range-parser "~1.2.1"
     statuses "2.0.1"
+
+serialize-javascript@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.0.tgz#efae5d88f45d7924141da8b5c3a7a7e663fefeb8"
+  integrity sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==
+  dependencies:
+    randombytes "^2.1.0"
 
 serialize-javascript@^6.0.1:
   version "6.0.2"
@@ -1947,6 +2472,35 @@ signal-exit@^4.0.1:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
+socket.io-adapter@~2.5.2:
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/socket.io-adapter/-/socket.io-adapter-2.5.4.tgz#4fdb1358667f6d68f25343353bd99bd11ee41006"
+  integrity sha512-wDNHGXGewWAjQPt3pyeYBtpWSq9cLE5UW1ZUPL/2eGK9jtse/FpXib7epSTsz0Q0m+6sg6Y4KtcFTlah1bdOVg==
+  dependencies:
+    debug "~4.3.4"
+    ws "~8.11.0"
+
+socket.io-parser@~4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.2.4.tgz#c806966cf7270601e47469ddeec30fbdfda44c83"
+  integrity sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==
+  dependencies:
+    "@socket.io/component-emitter" "~3.1.0"
+    debug "~4.3.1"
+
+socket.io@^4.7.2:
+  version "4.7.5"
+  resolved "https://registry.yarnpkg.com/socket.io/-/socket.io-4.7.5.tgz#56eb2d976aef9d1445f373a62d781a41c7add8f8"
+  integrity sha512-DmeAkF6cwM9jSfmp6Dr/5/mfMwb5Z5qRrSXLpo3Fq5SqyU8CMF15jIN4ZhfSwu35ksM1qmHZDQ/DK5XTccSTvA==
+  dependencies:
+    accepts "~1.3.4"
+    base64id "~2.0.0"
+    cors "~2.8.5"
+    debug "~4.3.2"
+    engine.io "~6.5.2"
+    socket.io-adapter "~2.5.2"
+    socket.io-parser "~4.2.4"
+
 sockjs@^0.3.24:
   version "0.3.24"
   resolved "https://registry.yarnpkg.com/sockjs/-/sockjs-0.3.24.tgz#c9bc8995f33a111bea0395ec30aa3206bdb5ccce"
@@ -1955,13 +2509,6 @@ sockjs@^0.3.24:
     faye-websocket "^0.11.3"
     uuid "^8.3.2"
     websocket-driver "^0.7.4"
-
-sonic-forest@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/sonic-forest/-/sonic-forest-1.0.3.tgz#81363af60017daba39b794fce24627dc412563cb"
-  integrity sha512-dtwajos6IWMEWXdEbW1IkEkyL2gztCAgDplRIX+OT5aRKnEd5e7r7YCxRgXZdhRP1FBdOBf8axeTPhzDv8T4wQ==
-  dependencies:
-    tree-dump "^1.0.0"
 
 source-map-js@^1.0.2:
   version "1.2.0"
@@ -1984,7 +2531,7 @@ source-map-support@0.5.21, source-map-support@~0.5.20:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
-source-map@^0.6.0:
+source-map@^0.6.0, source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
@@ -2017,13 +2564,21 @@ statuses@2.0.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
   integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
 
-"statuses@>= 1.4.0 < 2":
+"statuses@>= 1.4.0 < 2", statuses@~1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
-  name string-width-cjs
+streamroller@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/streamroller/-/streamroller-3.1.5.tgz#1263182329a45def1ffaef58d31b15d13d2ee7ff"
+  integrity sha512-KFxaM7XT+irxvdqSP1LGLgNWbYN7ay5owZ3r/8t77p+EtSUAfUgtl7be3xtqtOmGUl9K9YPO2ca8133RlTjvKw==
+  dependencies:
+    date-format "^4.0.14"
+    debug "^4.3.4"
+    fs-extra "^8.1.0"
+
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -2056,7 +2611,6 @@ string_decoder@~1.1.1:
     safe-buffer "~5.1.0"
 
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  name strip-ansi-cjs
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -2075,10 +2629,22 @@ strip-final-newline@^2.0.0:
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
-supports-color@^8.0.0:
+strip-json-comments@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
+  integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
+supports-color@8.1.1, supports-color@^8.0.0:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
+  dependencies:
+    has-flag "^4.0.0"
+
+supports-color@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   dependencies:
     has-flag "^4.0.0"
 
@@ -2123,6 +2689,11 @@ thunky@^1.0.2:
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
   integrity sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==
 
+tmp@^0.2.1:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.3.tgz#eb783cc22bc1e8bebd0671476d46ea4eb32a79ae"
+  integrity sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==
+
 to-regex-range@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
@@ -2135,7 +2706,7 @@ toidentifier@1.0.1:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
-tree-dump@^1.0.0:
+tree-dump@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/tree-dump/-/tree-dump-1.0.1.tgz#b448758da7495580e6b7830d6b7834fca4c45b96"
   integrity sha512-WCkcRBVPSlHHq1dc/px9iOfqklvzCbdRwvlNfxGZsrHqf6aZttfPrd7DJTt6oR10dwUfpFFQeVTkPbBIZxX/YA==
@@ -2158,17 +2729,27 @@ typescript@5.4.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.3.tgz#5c6fedd4c87bee01cd7a528a30145521f8e0feff"
   integrity sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==
 
+ua-parser-js@^0.7.30:
+  version "0.7.38"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.38.tgz#f497d8a4dc1fec6e854e5caa4b2f9913422ef054"
+  integrity sha512-fYmIy7fKTSFAhG3fuPlubeGaMoAd6r0rSnfEsO5nEY55i26KSLt9EH7PLQiiqPUhNqYIJvSkTy1oArIcXAbPbA==
+
 undici-types@~5.26.4:
   version "5.26.5"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
+
+universalify@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
+  integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==
 
-update-browserslist-db@^1.0.13:
+update-browserslist-db@^1.0.16:
   version "1.0.16"
   resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.16.tgz#f6d489ed90fb2f07d67784eb3f53d7891f736356"
   integrity sha512-KVbTxlBYlckhF5wgfyZXTWnMn7MMZjMu9XG8bPlliUOP9ThaF4QnhP8qrjrH7DRzHfSk0oQv1wToW+iA5GajEQ==
@@ -2198,10 +2779,15 @@ uuid@^8.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
-vary@~1.1.2:
+vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
+
+void-elements@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
+  integrity sha512-qZKX4RnBzH2ugr8Lxa7x+0V6XD9Sb/ouARtiasEQCHB1EVU4NXtmHsDDrx1dO4ne5fc3J6EW05BP1Dl0z0iung==
 
 watchpack@^2.4.1:
   version "2.4.1"
@@ -2285,6 +2871,13 @@ webpack-dev-server@5.0.4:
     webpack-dev-middleware "^7.1.0"
     ws "^8.16.0"
 
+webpack-merge@^4.1.5:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-4.2.2.tgz#a27c52ea783d1398afd2087f547d7b9d2f43634d"
+  integrity sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==
+  dependencies:
+    lodash "^4.17.15"
+
 webpack-merge@^5.7.3:
   version "5.10.0"
   resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-5.10.0.tgz#a3ad5d773241e9c682803abf628d4cd62b8a4177"
@@ -2343,6 +2936,13 @@ websocket-extensions@>=0.1.1:
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
   integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
 
+which@^1.2.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
+  integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
+  dependencies:
+    isexe "^2.0.0"
+
 which@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
@@ -2355,7 +2955,12 @@ wildcard@^2.0.0:
   resolved "https://registry.yarnpkg.com/wildcard/-/wildcard-2.0.1.tgz#5ab10d02487198954836b6349f74fff961e10f67"
   integrity sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+workerpool@6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
+  integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
+
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -2373,7 +2978,60 @@ wrap-ansi@^8.1.0:
     string-width "^5.0.1"
     strip-ansi "^7.0.1"
 
+wrappy@1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+  integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
+
 ws@^8.16.0:
-  version "8.17.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.17.0.tgz#d145d18eca2ed25aaf791a183903f7be5e295fea"
-  integrity sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==
+  version "8.17.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.17.1.tgz#9293da530bb548febc95371d90f9c878727d919b"
+  integrity sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==
+
+ws@~8.11.0:
+  version "8.11.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.11.0.tgz#6a0d36b8edfd9f96d8b25683db2f8d7de6e8e143"
+  integrity sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==
+
+y18n@^5.0.5:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
+  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
+yargs-parser@20.2.4:
+  version "20.2.4"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
+  integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
+
+yargs-parser@^20.2.2:
+  version "20.2.9"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
+  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
+
+yargs-unparser@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-unparser/-/yargs-unparser-2.0.0.tgz#f131f9226911ae5d9ad38c432fe809366c2325eb"
+  integrity sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==
+  dependencies:
+    camelcase "^6.0.0"
+    decamelize "^4.0.0"
+    flat "^5.0.2"
+    is-plain-obj "^2.1.0"
+
+yargs@16.2.0, yargs@^16.1.1:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
+  integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"
+
+yocto-queue@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
+  integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==

--- a/src/commonTest/kotlin/com/charleskorn/kaml/FlatFunSpec.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/FlatFunSpec.kt
@@ -1,0 +1,106 @@
+/*
+
+   Copyright 2018-2023 Charles Korn.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+*/
+
+package com.charleskorn.kaml
+
+import io.kotest.common.ExperimentalKotest
+import io.kotest.core.spec.KotestTestScope
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.scopes.FunSpecContainerScope
+import io.kotest.core.spec.style.scopes.RootTestWithConfigBuilder
+import io.kotest.core.test.TestScope
+import kotlin.jvm.JvmName
+
+private fun String.toContainerPrefix(): String = "$this -- "
+
+/**
+ * Flat version of a Kotest FunSpec for common and JS tests.
+ *
+ * WORKAROUND https://github.com/kotest/kotest/issues/3141 (Support for nested tests on JS target)
+ *
+ * Kotest 5 doesn't support nested tests in Kotlin/JS, so until it is supported
+ * this spec can be used, flattening all the nested tests to the root level.
+ * Limitation: context() bodies are non-suspendable, only test() bodies accept suspend functions.
+ *
+ * Posted by @BenWoodworth in Kotest issue #3141:
+ * https://github.com/kotest/kotest/issues/3141#issuecomment-1278433891
+ */
+// Using `abstract` causes a compiler error with native, so using `open` instead
+open class FlatFunSpec private constructor() : FunSpec() {
+    // Using primary constructor causes issue with Kotlin/JS IR:
+    // https://youtrack.jetbrains.com/issue/KT-54450
+    constructor(body: FlatFunSpec.() -> Unit = {}) : this() {
+        body()
+    }
+
+    // Overload context functions with non-nested versions
+    @JvmName("context\$FlatSpec")
+    fun context(name: String, test: FlatSpecContainerScope.() -> Unit): Unit =
+        test(FlatSpecContainerScope(this, name.toContainerPrefix(), false))
+
+    @JvmName("xcontext\$FlatSpec")
+    fun xcontext(name: String, test: FlatSpecContainerScope.() -> Unit): Unit =
+        test(FlatSpecContainerScope(this, name.toContainerPrefix(), true))
+
+    // Suppress FunSpec's context functions, so they can't be used
+    @Deprecated("Unsupported", level = DeprecationLevel.HIDDEN)
+    override fun context(name: String, test: suspend FunSpecContainerScope.() -> Unit): Nothing = error("Unsupported")
+
+    @Deprecated("Unsupported", level = DeprecationLevel.HIDDEN)
+    override fun xcontext(name: String, test: suspend FunSpecContainerScope.() -> Unit): Nothing = error("Unsupported")
+
+    @ExperimentalKotest
+    @Deprecated("Unsupported", level = DeprecationLevel.HIDDEN)
+    override fun context(name: String): Nothing = error("Unsupported")
+
+    @ExperimentalKotest
+    @Deprecated("Unsupported", level = DeprecationLevel.HIDDEN)
+    override fun xcontext(name: String): Nothing = error("Unsupported")
+}
+
+@Suppress("unused")
+@KotestTestScope
+class FlatSpecContainerScope(
+    private val spec: FlatFunSpec,
+    private val prefix: String,
+    private val ignored: Boolean,
+) {
+    fun test(name: String): RootTestWithConfigBuilder = if (ignored) {
+        spec.xtest(prefix + name)
+    } else {
+        spec.test(prefix + name)
+    }
+
+    fun test(name: String, test: suspend TestScope.() -> Unit): Unit = if (ignored) {
+        spec.xtest(prefix + name, test)
+    } else {
+        spec.test(prefix + name, test)
+    }
+
+    fun xtest(name: String): RootTestWithConfigBuilder = spec.xtest(prefix + name)
+
+    fun xtest(name: String, test: suspend TestScope.() -> Unit): Unit = spec.xtest(prefix + name, test)
+
+    fun context(name: String, test: FlatSpecContainerScope.() -> Unit): Unit = if (ignored) {
+        spec.xcontext(prefix + name, test)
+    } else {
+        spec.context(prefix + name, test)
+    }
+
+    fun xcontext(name: String, test: FlatSpecContainerScope.() -> Unit): Unit = spec.xcontext(prefix + name, test)
+}

--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlMapTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlMapTest.kt
@@ -21,12 +21,11 @@ package com.charleskorn.kaml
 import io.kotest.assertions.asClue
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 
-class YamlMapTest : DescribeSpec({
-    describe("a YAML map") {
-        describe("creating an instance") {
+class YamlMapTest : FlatFunSpec({
+    context("a YAML map") {
+        context("creating an instance") {
             val mapPath = YamlPath.root
             val key1Path = mapPath.withMapElementKey("key1", Location(4, 1))
             val key1ValuePath = key1Path.withMapElementValue(Location(4, 5))
@@ -34,13 +33,13 @@ class YamlMapTest : DescribeSpec({
             val key2ValuePath = key2Path.withMapElementValue(Location(6, 7))
 
             context("creating an empty map") {
-                it("does not throw an exception") {
+                test("does not throw an exception") {
                     shouldNotThrowAny { YamlMap(emptyMap(), mapPath) }
                 }
             }
 
             context("creating a map with a single entry") {
-                it("does not throw an exception") {
+                test("does not throw an exception") {
                     shouldNotThrowAny {
                         YamlMap(
                             mapOf(YamlScalar("key", key1Path) to YamlScalar("value", key1ValuePath)),
@@ -51,7 +50,7 @@ class YamlMapTest : DescribeSpec({
             }
 
             context("creating a map with two entries, each with unique keys") {
-                it("does not throw an exception") {
+                test("does not throw an exception") {
                     shouldNotThrowAny {
                         YamlMap(
                             mapOf(
@@ -65,7 +64,7 @@ class YamlMapTest : DescribeSpec({
             }
 
             context("creating a map with two entries with the same key") {
-                it("throws an appropriate exception") {
+                test("throws an appropriate exception") {
                     val exception = shouldThrow<DuplicateKeyException> {
                         YamlMap(
                             mapOf(
@@ -91,7 +90,7 @@ class YamlMapTest : DescribeSpec({
             }
         }
 
-        describe("testing equivalence") {
+        context("testing equivalence") {
             val mapPath = YamlPath.root
             val key1Path = mapPath.withMapElementKey("key1", Location(4, 1))
             val key1ValuePath = key1Path.withMapElementValue(Location(4, 5))
@@ -107,19 +106,19 @@ class YamlMapTest : DescribeSpec({
             )
 
             context("comparing it to the same instance") {
-                it("indicates that they are equivalent") {
+                test("indicates that they are equivalent") {
                     map.equivalentContentTo(map) shouldBe true
                 }
             }
 
             context("comparing it to another map with the same items in the same order with a different path") {
-                it("indicates that they are equivalent") {
+                test("indicates that they are equivalent") {
                     map.equivalentContentTo(YamlMap(map.entries, YamlPath.root.withListEntry(0, Location(3, 4)))) shouldBe true
                 }
             }
 
             context("comparing it to another map with the same items in a different order with the same path") {
-                it("indicates that they are equivalent") {
+                test("indicates that they are equivalent") {
                     map.equivalentContentTo(
                         YamlMap(
                             mapOf(
@@ -133,7 +132,7 @@ class YamlMapTest : DescribeSpec({
             }
 
             context("comparing it to another map with different keys with the same path") {
-                it("indicates that they are not equivalent") {
+                test("indicates that they are not equivalent") {
                     map.equivalentContentTo(
                         YamlMap(
                             mapOf(
@@ -147,7 +146,7 @@ class YamlMapTest : DescribeSpec({
             }
 
             context("comparing it to another map with different values with the same path") {
-                it("indicates that they are not equivalent") {
+                test("indicates that they are not equivalent") {
                     map.equivalentContentTo(
                         YamlMap(
                             mapOf(
@@ -161,31 +160,31 @@ class YamlMapTest : DescribeSpec({
             }
 
             context("comparing it to another map with different items with the same path") {
-                it("indicates that they are not equivalent") {
+                test("indicates that they are not equivalent") {
                     map.equivalentContentTo(YamlMap(emptyMap(), map.path)) shouldBe false
                 }
             }
 
             context("comparing it to a scalar value") {
-                it("indicates that they are not equivalent") {
+                test("indicates that they are not equivalent") {
                     map.equivalentContentTo(YamlScalar("some content", map.path)) shouldBe false
                 }
             }
 
             context("comparing it to a null value") {
-                it("indicates that they are not equivalent") {
+                test("indicates that they are not equivalent") {
                     map.equivalentContentTo(YamlNull(map.path)) shouldBe false
                 }
             }
 
             context("comparing it to a list") {
-                it("indicates that they are not equivalent") {
+                test("indicates that they are not equivalent") {
                     map.equivalentContentTo(YamlList(emptyList(), map.path)) shouldBe false
                 }
             }
         }
 
-        describe("converting the content to a human-readable string") {
+        context("converting the content to a human-readable string") {
             val helloKeyPath = YamlPath.root.withMapElementKey("hello", Location(1, 1))
             val helloValuePath = helloKeyPath.withMapElementValue(Location(2, 1))
             val alsoKeyPath = YamlPath.root.withMapElementKey("also", Location(3, 1))
@@ -194,7 +193,7 @@ class YamlMapTest : DescribeSpec({
             context("an empty map") {
                 val map = YamlMap(emptyMap(), YamlPath.root)
 
-                it("returns empty curly brackets") {
+                test("returns empty curly brackets") {
                     map.contentToString() shouldBe "{}"
                 }
             }
@@ -207,7 +206,7 @@ class YamlMapTest : DescribeSpec({
                     YamlPath.root,
                 )
 
-                it("returns that item surrounded by curly brackets") {
+                test("returns that item surrounded by curly brackets") {
                     map.contentToString() shouldBe "{'hello': 'world'}"
                 }
             }
@@ -221,13 +220,13 @@ class YamlMapTest : DescribeSpec({
                     YamlPath.root,
                 )
 
-                it("returns all items separated by commas and surrounded by curly brackets") {
+                test("returns all items separated by commas and surrounded by curly brackets") {
                     map.contentToString() shouldBe "{'hello': 'world', 'also': 'thanks'}"
                 }
             }
         }
 
-        describe("getting elements of the map") {
+        context("getting elements of the map") {
             val helloKeyPath = YamlPath.root.withMapElementKey("hello", Location(1, 1))
             val helloValuePath = helloKeyPath.withMapElementValue(Location(2, 1))
             val alsoKeyPath = YamlPath.root.withMapElementKey("also", Location(3, 1))
@@ -242,19 +241,19 @@ class YamlMapTest : DescribeSpec({
             )
 
             context("the key is not in the map") {
-                it("returns null") {
+                test("returns null") {
                     map.get<YamlScalar>("something else") shouldBe null
                 }
             }
 
             context("the key is in the map") {
-                it("returns the value for that key") {
+                test("returns the value for that key") {
                     map.get<YamlScalar>("hello") shouldBe YamlScalar("world", helloValuePath)
                 }
             }
         }
 
-        describe("getting scalar elements of the map") {
+        context("getting scalar elements of the map") {
             val helloKeyPath = YamlPath.root.withMapElementKey("hello", Location(1, 1))
             val helloValuePath = helloKeyPath.withMapElementValue(Location(2, 1))
             val alsoKeyPath = YamlPath.root.withMapElementKey("also", Location(3, 1))
@@ -270,19 +269,19 @@ class YamlMapTest : DescribeSpec({
             )
 
             context("the key is not in the map") {
-                it("returns null") {
+                test("returns null") {
                     map.getScalar("something else") shouldBe null
                 }
             }
 
             context("the key is in the map and has a scalar value") {
-                it("returns the value for that key") {
+                test("returns the value for that key") {
                     map.getScalar("hello") shouldBe YamlScalar("world", helloValuePath)
                 }
             }
 
             context("the key is in the map but does not have a scalar value") {
-                it("returns the value for that key") {
+                test("returns the value for that key") {
                     val exception = shouldThrow<IncorrectTypeException> { map.getScalar("also") }
 
                     exception.asClue {
@@ -295,7 +294,7 @@ class YamlMapTest : DescribeSpec({
             }
         }
 
-        describe("getting keys of the map") {
+        context("getting keys of the map") {
             val helloKeyPath = YamlPath.root.withMapElementKey("hello", Location(1, 1))
             val helloValuePath = helloKeyPath.withMapElementValue(Location(2, 1))
             val alsoKeyPath = YamlPath.root.withMapElementKey("also", Location(3, 1))
@@ -310,19 +309,19 @@ class YamlMapTest : DescribeSpec({
             )
 
             context("the key is not in the map") {
-                it("returns null") {
+                test("returns null") {
                     map.getKey("something else") shouldBe null
                 }
             }
 
             context("the key is in the map") {
-                it("returns the node for that key") {
+                test("returns the node for that key") {
                     map.getKey("hello") shouldBe YamlScalar("hello", helloKeyPath)
                 }
             }
         }
 
-        describe("replacing its path") {
+        context("replacing its path") {
             val originalPath = YamlPath.root
             val originalKey1Path = originalPath.withMapElementKey("key1", Location(4, 1))
             val originalKey1ValuePath = originalKey1Path.withMapElementValue(Location(4, 5))
@@ -351,12 +350,12 @@ class YamlMapTest : DescribeSpec({
                 newPath,
             )
 
-            it("returns a new map node with the path for the node and its keys and values updated to the new path") {
+            test("returns a new map node with the path for the node and its keys and values updated to the new path") {
                 original.withPath(newPath) shouldBe expected
             }
         }
 
-        describe("converting it to a string") {
+        context("converting it to a string") {
             val path = YamlPath.root.withMapElementKey("test", Location(2, 1)).withMapElementValue(Location(2, 7))
             val keyPath = path.withMapElementKey("something", Location(3, 3))
             val valuePath = keyPath.withMapElementValue(Location(3, 7))
@@ -367,7 +366,7 @@ class YamlMapTest : DescribeSpec({
                 path,
             )
 
-            it("returns a human-readable description of itself") {
+            test("returns a human-readable description of itself") {
                 value.toString() shouldBe
                     """
                         map @ $path (size: 1)

--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlPathTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlPathTest.kt
@@ -21,14 +21,13 @@ package com.charleskorn.kaml
 import io.kotest.assertions.asClue
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 
-class YamlPathTest : DescribeSpec({
-    describe("a YAML path") {
-        describe("creating a path") {
-            describe("given an empty list of segments") {
-                it("throws an exception") {
+class YamlPathTest : FlatFunSpec({
+    context("a YAML path") {
+        context("creating a path") {
+            context("given an empty list of segments") {
+                test("throws an exception") {
                     val exception = shouldThrow<IllegalArgumentException> { YamlPath(emptyList()) }
 
                     exception.asClue {
@@ -37,20 +36,20 @@ class YamlPathTest : DescribeSpec({
                 }
             }
 
-            describe("given a list of segments where the first element is the root element") {
-                it("does not throw an exception") {
+            context("given a list of segments where the first element is the root element") {
+                test("does not throw an exception") {
                     shouldNotThrowAny { YamlPath(YamlPathSegment.Root) }
                 }
             }
 
-            describe("given a list of segments where the first element is an alias definition") {
-                it("does not throw an exception") {
+            context("given a list of segments where the first element is an alias definition") {
+                test("does not throw an exception") {
                     shouldNotThrowAny { YamlPath(YamlPathSegment.AliasDefinition("blah", Location(2, 3))) }
                 }
             }
 
-            describe("given a list of segments where the first element is not the root element or an alias definition") {
-                it("throws an exception") {
+            context("given a list of segments where the first element is not the root element or an alias definition") {
+                test("throws an exception") {
                     val exception = shouldThrow<IllegalArgumentException> { YamlPath(YamlPathSegment.Error(Location(1, 2))) }
 
                     exception.asClue {
@@ -59,8 +58,8 @@ class YamlPathTest : DescribeSpec({
                 }
             }
 
-            describe("given a list of segments where the root element appears but not as the first element") {
-                it("throws an exception") {
+            context("given a list of segments where the root element appears but not as the first element") {
+                test("throws an exception") {
                     val exception = shouldThrow<IllegalArgumentException> { YamlPath(YamlPathSegment.Error(Location(1, 2)), YamlPathSegment.Root) }
 
                     exception.asClue {
@@ -69,8 +68,8 @@ class YamlPathTest : DescribeSpec({
                 }
             }
 
-            describe("given a list of segments where the root element appears multiple times") {
-                it("throws an exception") {
+            context("given a list of segments where the root element appears multiple times") {
+                test("throws an exception") {
                     val exception = shouldThrow<IllegalArgumentException> { YamlPath(YamlPathSegment.Root, YamlPathSegment.Error(Location(1, 2)), YamlPathSegment.Root) }
 
                     exception.asClue {
@@ -80,221 +79,221 @@ class YamlPathTest : DescribeSpec({
             }
         }
 
-        describe("getting the end location of a path") {
-            describe("given a path with just the root element") {
+        context("getting the end location of a path") {
+            context("given a path with just the root element") {
                 val path = YamlPath(YamlPathSegment.Root)
 
-                it("returns the first character of the document") {
+                test("returns the first character of the document") {
                     path.endLocation shouldBe Location(1, 1)
                 }
             }
 
-            describe("given a path with multiple elements") {
+            context("given a path with multiple elements") {
                 val path = YamlPath(
                     YamlPathSegment.Root,
                     YamlPathSegment.ListEntry(2, Location(3, 4)),
                     YamlPathSegment.MapElementKey("something", Location(5, 6)),
                 )
 
-                it("returns the location of the last element of the path") {
+                test("returns the location of the last element of the path") {
                     path.endLocation shouldBe Location(5, 6)
                 }
             }
         }
 
-        describe("converting a path to a string suitable for display to a user") {
-            describe("given a path with just the root element") {
+        context("converting a path to a string suitable for display to a user") {
+            context("given a path with just the root element") {
                 val path = YamlPath.root
 
-                it("returns a description of the root element") {
+                test("returns a description of the root element") {
                     path.toHumanReadableString() shouldBe "<root>"
                 }
             }
 
-            describe("given a path with an error after the root element") {
+            context("given a path with an error after the root element") {
                 val path = YamlPath.root
                     .withError(Location(2, 3))
 
-                it("returns a description of the root element") {
+                test("returns a description of the root element") {
                     path.toHumanReadableString() shouldBe "<root>"
                 }
             }
 
-            describe("given a path with an error on a non-root element") {
+            context("given a path with an error on a non-root element") {
                 val path = YamlPath.root
                     .withListEntry(2, Location(2, 3))
                     .withError(Location(2, 3))
 
-                it("returns a description of the parent of the error") {
+                test("returns a description of the parent of the error") {
                     path.toHumanReadableString() shouldBe "[2]"
                 }
             }
 
-            describe("given a path with a list entry after the root element") {
+            context("given a path with a list entry after the root element") {
                 val path = YamlPath.root
                     .withListEntry(2, Location(2, 3))
 
-                it("returns a description of the list entry") {
+                test("returns a description of the list entry") {
                     path.toHumanReadableString() shouldBe "[2]"
                 }
             }
 
-            describe("given a path with a map key after the root element") {
+            context("given a path with a map key after the root element") {
                 val path = YamlPath.root
                     .withMapElementKey("colour", Location(2, 3))
 
-                it("returns a description of the map key") {
+                test("returns a description of the map key") {
                     path.toHumanReadableString() shouldBe "colour"
                 }
             }
 
-            describe("given a path with a map key followed by its value") {
+            context("given a path with a map key followed by its value") {
                 val path = YamlPath.root
                     .withMapElementKey("colour", Location(2, 3))
                     .withMapElementValue(Location(2, 11))
 
-                it("returns a description of the map key") {
+                test("returns a description of the map key") {
                     path.toHumanReadableString() shouldBe "colour"
                 }
             }
 
-            describe("given a path for a nested map's key") {
+            context("given a path for a nested map's key") {
                 val path = YamlPath.root
                     .withMapElementKey("colour", Location(2, 3))
                     .withMapElementValue(Location(2, 11))
                     .withMapElementKey("brightness", Location(3, 5))
 
-                it("returns a description of the nested map key") {
+                test("returns a description of the nested map key") {
                     path.toHumanReadableString() shouldBe "colour.brightness"
                 }
             }
 
-            describe("given a path for a nested list entry") {
+            context("given a path for a nested list entry") {
                 val path = YamlPath.root
                     .withListEntry(1, Location(2, 3))
                     .withListEntry(4, Location(3, 5))
 
-                it("returns a description of the nested list entry") {
+                test("returns a description of the nested list entry") {
                     path.toHumanReadableString() shouldBe "[1][4]"
                 }
             }
 
-            describe("given a path for a list nested within an object") {
+            context("given a path for a list nested within an object") {
                 val path = YamlPath.root
                     .withMapElementKey("colours", Location(2, 3))
                     .withListEntry(4, Location(3, 5))
 
-                it("returns a description of the nested list entry") {
+                test("returns a description of the nested list entry") {
                     path.toHumanReadableString() shouldBe "colours[4]"
                 }
             }
 
-            describe("given a path for an object key nested within a list") {
+            context("given a path for an object key nested within a list") {
                 val path = YamlPath.root
                     .withListEntry(1, Location(2, 3))
                     .withMapElementKey("colour", Location(3, 5))
 
-                it("returns a description of the nested object key") {
+                test("returns a description of the nested object key") {
                     path.toHumanReadableString() shouldBe "[1].colour"
                 }
             }
 
-            describe("given a path for a reference to an alias") {
+            context("given a path for a reference to an alias") {
                 val path = YamlPath.root
                     .withAliasReference("blue", Location(2, 3))
 
-                it("returns a description of the alias reference") {
+                test("returns a description of the alias reference") {
                     path.toHumanReadableString() shouldBe "->&blue"
                 }
             }
 
-            describe("given a path for a reference to an alias nested within an object") {
+            context("given a path for a reference to an alias nested within an object") {
                 val path = YamlPath.root
                     .withMapElementKey("colour", Location(2, 3))
                     .withAliasReference("blue", Location(3, 7))
 
-                it("returns a description of the nested alias reference") {
+                test("returns a description of the nested alias reference") {
                     path.toHumanReadableString() shouldBe "colour->&blue"
                 }
             }
 
-            describe("given a path for a reference to an alias nested within a list") {
+            context("given a path for a reference to an alias nested within a list") {
                 val path = YamlPath.root
                     .withMapElementKey("colours", Location(2, 3))
                     .withListEntry(4, Location(3, 5))
                     .withAliasReference("blue", Location(3, 7))
 
-                it("returns a description of the nested alias reference") {
+                test("returns a description of the nested alias reference") {
                     path.toHumanReadableString() shouldBe "colours[4]->&blue"
                 }
             }
 
-            describe("given a path for a reference to a resolved alias") {
+            context("given a path for a reference to a resolved alias") {
                 val path = YamlPath.root
                     .withAliasReference("blue", Location(2, 3))
                     .withAliasDefinition("blue", Location(1, 2))
 
-                it("returns a description of the alias reference") {
+                test("returns a description of the alias reference") {
                     path.toHumanReadableString() shouldBe "->&blue"
                 }
             }
 
-            describe("given a path for a reference to a resolved alias map's element") {
+            context("given a path for a reference to a resolved alias map's element") {
                 val path = YamlPath.root
                     .withAliasReference("blue", Location(2, 3))
                     .withAliasDefinition("blue", Location(1, 2))
                     .withMapElementKey("saturation", Location(1, 5))
 
-                it("returns a description of the element key") {
+                test("returns a description of the element key") {
                     path.toHumanReadableString() shouldBe "->&blue.saturation"
                 }
             }
 
-            describe("given a path for a reference to a resolved alias list's element") {
+            context("given a path for a reference to a resolved alias list's element") {
                 val path = YamlPath.root
                     .withAliasReference("blue", Location(2, 3))
                     .withAliasDefinition("blue", Location(1, 2))
                     .withListEntry(3, Location(1, 5))
 
-                it("returns a description of the element key") {
+                test("returns a description of the element key") {
                     path.toHumanReadableString() shouldBe "->&blue[3]"
                 }
             }
 
-            describe("given a path for a reference to an inline merged object") {
+            context("given a path for a reference to an inline merged object") {
                 val path = YamlPath.root
                     .withMapElementKey("colour", Location(1, 3))
                     .withMerge(Location(4, 5))
 
-                it("returns a description of the object") {
+                test("returns a description of the object") {
                     path.toHumanReadableString() shouldBe "colour>>(merged)"
                 }
             }
 
-            describe("given a path for a reference to an inline merged object that was part of a list of objects to merge") {
+            context("given a path for a reference to an inline merged object that was part of a list of objects to merge") {
                 // eg. << : [ { x: 123 }, { y: 456 } ]
                 val path = YamlPath.root
                     .withMapElementKey("colour", Location(1, 3))
                     .withMerge(Location(4, 5))
                     .withListEntry(1, Location(4, 10))
 
-                it("returns a description of the object") {
+                test("returns a description of the object") {
                     path.toHumanReadableString() shouldBe "colour>>(merged entry 1)"
                 }
             }
 
-            describe("given a path for a reference to an inline merged object's key") {
+            context("given a path for a reference to an inline merged object's key") {
                 val path = YamlPath.root
                     .withMapElementKey("colour", Location(1, 3))
                     .withMerge(Location(4, 5))
                     .withMapElementKey("saturation", Location(4, 7))
 
-                it("returns a description of the element key") {
+                test("returns a description of the element key") {
                     path.toHumanReadableString() shouldBe "colour>>(merged).saturation"
                 }
             }
 
-            describe("given a path for a reference to the key of a merged object from an alias") {
+            context("given a path for a reference to the key of a merged object from an alias") {
                 val path = YamlPath.root
                     .withMapElementKey("colour", Location(1, 3))
                     .withMerge(Location(4, 5))
@@ -302,12 +301,12 @@ class YamlPathTest : DescribeSpec({
                     .withAliasDefinition("blue", Location(10, 3))
                     .withMapElementKey("saturation", Location(11, 5))
 
-                it("returns a description of the element key") {
+                test("returns a description of the element key") {
                     path.toHumanReadableString() shouldBe "colour>>(merged &blue).saturation"
                 }
             }
 
-            describe("given a path for a reference to the key of a merged object from an alias that was part of a list of objects to merge") {
+            context("given a path for a reference to the key of a merged object from an alias that was part of a list of objects to merge") {
                 // eg. << : [ &blue, &green ]
                 val path = YamlPath.root
                     .withMapElementKey("colour", Location(1, 3))
@@ -317,7 +316,7 @@ class YamlPathTest : DescribeSpec({
                     .withAliasDefinition("green", Location(10, 3))
                     .withMapElementKey("saturation", Location(11, 5))
 
-                it("returns a description of the element key") {
+                test("returns a description of the element key") {
                     path.toHumanReadableString() shouldBe "colour>>(merged entry 1 &green).saturation"
                 }
             }

--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlReadingTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlReadingTest.kt
@@ -36,7 +36,6 @@ import com.charleskorn.kaml.testobjects.UnwrappedString
 import com.charleskorn.kaml.testobjects.polymorphicModule
 import io.kotest.assertions.asClue
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.serialization.Contextual
@@ -61,16 +60,16 @@ import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.modules.serializersModuleOf
 import kotlin.jvm.JvmInline
 
-class YamlReadingTest : DescribeSpec({
-    describe("a YAML parser") {
-        describe("parsing scalars") {
+class YamlReadingTest : FlatFunSpec({
+    context("a YAML parser") {
+        context("parsing scalars") {
             context("given the input 'hello'") {
                 val input = "hello"
 
                 context("parsing that input as a string") {
                     val result = Yaml.default.decodeFromString(String.serializer(), input)
 
-                    it("deserializes it to the expected string value") {
+                    test("deserializes it to the expected string value") {
                         result shouldBe "hello"
                     }
                 }
@@ -78,13 +77,13 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input as a nullable string") {
                     val result = Yaml.default.decodeFromString(String.serializer().nullable, input)
 
-                    it("deserializes it to the expected string value") {
+                    test("deserializes it to the expected string value") {
                         result shouldBe "hello"
                     }
                 }
 
                 context("parsing that input with a serializer that uses YAML location information when throwing exceptions") {
-                    it("throws an exception with the correct location information") {
+                    test("throws an exception with the correct location information") {
                         val exception = shouldThrow<LocationInformationException> { Yaml.default.decodeFromString(LocationThrowingSerializer, input) }
 
                         exception.asClue {
@@ -96,7 +95,7 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input as a value type") {
                     val result = Yaml.default.decodeFromString(StringValue.serializer(), input)
 
-                    it("deserializes it to the expected object") {
+                    test("deserializes it to the expected object") {
                         result shouldBe StringValue("hello")
                     }
                 }
@@ -108,7 +107,7 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input as an integer") {
                     val result = Yaml.default.decodeFromString(Int.serializer(), input)
 
-                    it("deserializes it to the expected integer") {
+                    test("deserializes it to the expected integer") {
                         result shouldBe 123
                     }
                 }
@@ -116,7 +115,7 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input as a long") {
                     val result = Yaml.default.decodeFromString(Long.serializer(), input)
 
-                    it("deserializes it to the expected long") {
+                    test("deserializes it to the expected long") {
                         result shouldBe 123
                     }
                 }
@@ -124,7 +123,7 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input as a short") {
                     val result = Yaml.default.decodeFromString(Short.serializer(), input)
 
-                    it("deserializes it to the expected short") {
+                    test("deserializes it to the expected short") {
                         result shouldBe 123
                     }
                 }
@@ -132,7 +131,7 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input as a byte") {
                     val result = Yaml.default.decodeFromString(Byte.serializer(), input)
 
-                    it("deserializes it to the expected byte") {
+                    test("deserializes it to the expected byte") {
                         result shouldBe 123
                     }
                 }
@@ -140,7 +139,7 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input as a double") {
                     val result = Yaml.default.decodeFromString(Double.serializer(), input)
 
-                    it("deserializes it to the expected double") {
+                    test("deserializes it to the expected double") {
                         result shouldBe 123.0
                     }
                 }
@@ -148,7 +147,7 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input as a float") {
                     val result = Yaml.default.decodeFromString(Float.serializer(), input)
 
-                    it("deserializes it to the expected float") {
+                    test("deserializes it to the expected float") {
                         result shouldBe 123.0f
                     }
                 }
@@ -156,7 +155,7 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input as a nullable integer") {
                     val result = Yaml.default.decodeFromString(Int.serializer().nullable, input)
 
-                    it("deserializes it to the expected integer") {
+                    test("deserializes it to the expected integer") {
                         result shouldBe 123
                     }
                 }
@@ -164,7 +163,7 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input as a nullable long") {
                     val result = Yaml.default.decodeFromString(Long.serializer().nullable, input)
 
-                    it("deserializes it to the expected long") {
+                    test("deserializes it to the expected long") {
                         result shouldBe 123
                     }
                 }
@@ -172,7 +171,7 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input as a nullable short") {
                     val result = Yaml.default.decodeFromString(Short.serializer().nullable, input)
 
-                    it("deserializes it to the expected short") {
+                    test("deserializes it to the expected short") {
                         result shouldBe 123
                     }
                 }
@@ -180,7 +179,7 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input as a nullable byte") {
                     val result = Yaml.default.decodeFromString(Byte.serializer().nullable, input)
 
-                    it("deserializes it to the expected byte") {
+                    test("deserializes it to the expected byte") {
                         result shouldBe 123
                     }
                 }
@@ -188,7 +187,7 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input as a nullable double") {
                     val result = Yaml.default.decodeFromString(Double.serializer().nullable, input)
 
-                    it("deserializes it to the expected double") {
+                    test("deserializes it to the expected double") {
                         result shouldBe 123.0
                     }
                 }
@@ -196,7 +195,7 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input as a nullable float") {
                     val result = Yaml.default.decodeFromString(Float.serializer().nullable, input)
 
-                    it("deserializes it to the expected float") {
+                    test("deserializes it to the expected float") {
                         result shouldBe 123.0f
                     }
                 }
@@ -208,7 +207,7 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input as a boolean") {
                     val result = Yaml.default.decodeFromString(Boolean.serializer(), input)
 
-                    it("deserializes it to the expected boolean value") {
+                    test("deserializes it to the expected boolean value") {
                         result shouldBe true
                     }
                 }
@@ -216,7 +215,7 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input as a nullable boolean") {
                     val result = Yaml.default.decodeFromString(Boolean.serializer().nullable, input)
 
-                    it("deserializes it to the expected boolean value") {
+                    test("deserializes it to the expected boolean value") {
                         result shouldBe true
                     }
                 }
@@ -228,7 +227,7 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input as a character") {
                     val result = Yaml.default.decodeFromString(Char.serializer(), input)
 
-                    it("deserializes it to the expected character value") {
+                    test("deserializes it to the expected character value") {
                         result shouldBe 'c'
                     }
                 }
@@ -236,7 +235,7 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input as a nullable character") {
                     val result = Yaml.default.decodeFromString(Char.serializer().nullable, input)
 
-                    it("deserializes it to the expected character value") {
+                    test("deserializes it to the expected character value") {
                         result shouldBe 'c'
                     }
                 }
@@ -256,7 +255,7 @@ class YamlReadingTest : DescribeSpec({
                     context("parsing that input as an enumeration value") {
                         val result = Yaml.default.decodeFromString(serializer, input)
 
-                        it("deserializes it to the expected enumeration value") {
+                        test("deserializes it to the expected enumeration value") {
                             result shouldBe expectedValue
                         }
                     }
@@ -264,7 +263,7 @@ class YamlReadingTest : DescribeSpec({
             }
 
             context("parsing an invalid enumeration value") {
-                it("throws an appropriate exception") {
+                test("throws an appropriate exception") {
                     val exception = shouldThrow<YamlScalarFormatException> { Yaml.default.decodeFromString(TestEnum.serializer(), "nonsense") }
 
                     exception.asClue {
@@ -277,19 +276,19 @@ class YamlReadingTest : DescribeSpec({
             }
         }
 
-        describe("parsing null values") {
+        context("parsing null values") {
             val input = "null"
 
             context("parsing a null value as a nullable string") {
                 val result = Yaml.default.decodeFromString(String.serializer().nullable, input)
 
-                it("returns a null value") {
+                test("returns a null value") {
                     result shouldBe null
                 }
             }
 
             context("parsing a null value as a non-nullable string") {
-                it("throws an appropriate exception") {
+                test("throws an appropriate exception") {
                     val exception = shouldThrow<UnexpectedNullValueException> { Yaml.default.decodeFromString(String.serializer(), input) }
 
                     exception.asClue {
@@ -304,13 +303,13 @@ class YamlReadingTest : DescribeSpec({
             context("parsing a null value as a nullable integer") {
                 val result = Yaml.default.decodeFromString(Int.serializer().nullable, input)
 
-                it("returns a null value") {
+                test("returns a null value") {
                     result shouldBe null
                 }
             }
 
             context("parsing a null value as a non-nullable integer") {
-                it("throws an appropriate exception") {
+                test("throws an appropriate exception") {
                     val exception = shouldThrow<UnexpectedNullValueException> { Yaml.default.decodeFromString(Int.serializer(), input) }
 
                     exception.asClue {
@@ -325,13 +324,13 @@ class YamlReadingTest : DescribeSpec({
             context("parsing a null value as a nullable long") {
                 val result = Yaml.default.decodeFromString(Long.serializer().nullable, input)
 
-                it("returns a null value") {
+                test("returns a null value") {
                     result shouldBe null
                 }
             }
 
             context("parsing a null value as a non-nullable long") {
-                it("throws an appropriate exception") {
+                test("throws an appropriate exception") {
                     val exception = shouldThrow<UnexpectedNullValueException> { Yaml.default.decodeFromString(Long.serializer(), input) }
 
                     exception.asClue {
@@ -346,13 +345,13 @@ class YamlReadingTest : DescribeSpec({
             context("parsing a null value as a nullable short") {
                 val result = Yaml.default.decodeFromString(Short.serializer().nullable, input)
 
-                it("returns a null value") {
+                test("returns a null value") {
                     result shouldBe null
                 }
             }
 
             context("parsing a null value as a non-nullable short") {
-                it("throws an appropriate exception") {
+                test("throws an appropriate exception") {
                     val exception = shouldThrow<UnexpectedNullValueException> { Yaml.default.decodeFromString(Short.serializer(), input) }
 
                     exception.asClue {
@@ -367,13 +366,13 @@ class YamlReadingTest : DescribeSpec({
             context("parsing a null value as a nullable byte") {
                 val result = Yaml.default.decodeFromString(Byte.serializer().nullable, input)
 
-                it("returns a null value") {
+                test("returns a null value") {
                     result shouldBe null
                 }
             }
 
             context("parsing a null value as a non-nullable byte") {
-                it("throws an appropriate exception") {
+                test("throws an appropriate exception") {
                     val exception = shouldThrow<UnexpectedNullValueException> { Yaml.default.decodeFromString(Byte.serializer(), input) }
 
                     exception.asClue {
@@ -388,13 +387,13 @@ class YamlReadingTest : DescribeSpec({
             context("parsing a null value as a nullable double") {
                 val result = Yaml.default.decodeFromString(Double.serializer().nullable, input)
 
-                it("returns a null value") {
+                test("returns a null value") {
                     result shouldBe null
                 }
             }
 
             context("parsing a null value as a non-nullable double") {
-                it("throws an appropriate exception") {
+                test("throws an appropriate exception") {
                     val exception = shouldThrow<UnexpectedNullValueException> { Yaml.default.decodeFromString(Double.serializer(), input) }
 
                     exception.asClue {
@@ -409,13 +408,13 @@ class YamlReadingTest : DescribeSpec({
             context("parsing a null value as a nullable float") {
                 val result = Yaml.default.decodeFromString(Float.serializer().nullable, input)
 
-                it("returns a null value") {
+                test("returns a null value") {
                     result shouldBe null
                 }
             }
 
             context("parsing a null value as a non-nullable float") {
-                it("throws an appropriate exception") {
+                test("throws an appropriate exception") {
                     val exception = shouldThrow<UnexpectedNullValueException> { Yaml.default.decodeFromString(Float.serializer(), input) }
 
                     exception.asClue {
@@ -430,13 +429,13 @@ class YamlReadingTest : DescribeSpec({
             context("parsing a null value as a nullable boolean") {
                 val result = Yaml.default.decodeFromString(Boolean.serializer().nullable, input)
 
-                it("returns a null value") {
+                test("returns a null value") {
                     result shouldBe null
                 }
             }
 
             context("parsing a null value as a non-nullable boolean") {
-                it("throws an appropriate exception") {
+                test("throws an appropriate exception") {
                     val exception = shouldThrow<UnexpectedNullValueException> { Yaml.default.decodeFromString(Boolean.serializer(), input) }
 
                     exception.asClue {
@@ -451,13 +450,13 @@ class YamlReadingTest : DescribeSpec({
             context("parsing a null value as a nullable character") {
                 val result = Yaml.default.decodeFromString(Char.serializer().nullable, input)
 
-                it("returns a null value") {
+                test("returns a null value") {
                     result shouldBe null
                 }
             }
 
             context("parsing a null value as a non-nullable character") {
-                it("throws an appropriate exception") {
+                test("throws an appropriate exception") {
                     val exception = shouldThrow<UnexpectedNullValueException> { Yaml.default.decodeFromString(Char.serializer(), input) }
 
                     exception.asClue {
@@ -472,13 +471,13 @@ class YamlReadingTest : DescribeSpec({
             context("parsing a null value as a nullable enum") {
                 val result = Yaml.default.decodeFromString(TestEnum.serializer().nullable, input)
 
-                it("returns a null value") {
+                test("returns a null value") {
                     result shouldBe null
                 }
             }
 
             context("parsing a null value as a non-nullable enum") {
-                it("throws an appropriate exception") {
+                test("throws an appropriate exception") {
                     val exception = shouldThrow<UnexpectedNullValueException> { Yaml.default.decodeFromString(TestEnum.serializer(), input) }
 
                     exception.asClue {
@@ -493,13 +492,13 @@ class YamlReadingTest : DescribeSpec({
             context("parsing a null value as a nullable list") {
                 val result = Yaml.default.decodeFromString(ListSerializer(String.serializer()).nullable, input)
 
-                it("returns a null value") {
+                test("returns a null value") {
                     result shouldBe null
                 }
             }
 
             context("parsing a null value as a non-nullable list") {
-                it("throws an appropriate exception") {
+                test("throws an appropriate exception") {
                     val exception = shouldThrow<UnexpectedNullValueException> { Yaml.default.decodeFromString(ListSerializer(String.serializer()), input) }
 
                     exception.asClue {
@@ -514,13 +513,13 @@ class YamlReadingTest : DescribeSpec({
             context("parsing a null value as a nullable object") {
                 val result = Yaml.default.decodeFromString(ComplexStructure.serializer().nullable, input)
 
-                it("returns a null value") {
+                test("returns a null value") {
                     result shouldBe null
                 }
             }
 
             context("parsing a null value as a non-nullable object") {
-                it("throws an appropriate exception") {
+                test("throws an appropriate exception") {
                     val exception = shouldThrow<UnexpectedNullValueException> { Yaml.default.decodeFromString(ComplexStructure.serializer(), input) }
 
                     exception.asClue {
@@ -533,7 +532,7 @@ class YamlReadingTest : DescribeSpec({
             }
 
             context("parsing a null value with a serializer that uses YAML location information when throwing exceptions") {
-                it("throws an exception with the correct location information") {
+                test("throws an exception with the correct location information") {
                     val exception = shouldThrow<LocationInformationException> { Yaml.default.decodeFromString(LocationThrowingSerializer, input) }
 
                     exception.asClue {
@@ -552,7 +551,7 @@ class YamlReadingTest : DescribeSpec({
                     configuration = YamlConfiguration(yamlNamingStrategy = YamlNamingStrategy.SnakeCase),
                 ).decodeFromString(NamingStrategyTestData.serializer(), "serial_name: value")
 
-                it("correctly serializes into the data class") {
+                test("correctly serializes into the data class") {
                     output shouldBe NamingStrategyTestData("value")
                 }
             }
@@ -562,7 +561,7 @@ class YamlReadingTest : DescribeSpec({
                     configuration = YamlConfiguration(yamlNamingStrategy = YamlNamingStrategy.PascalCase),
                 ).decodeFromString(NamingStrategyTestData.serializer(), "SerialName: value")
 
-                it("correctly serializes into the data class") {
+                test("correctly serializes into the data class") {
                     output shouldBe NamingStrategyTestData("value")
                 }
             }
@@ -572,13 +571,13 @@ class YamlReadingTest : DescribeSpec({
                     configuration = YamlConfiguration(yamlNamingStrategy = YamlNamingStrategy.CamelCase),
                 ).decodeFromString(NamingStrategyTestData.serializer(), "serialName: value")
 
-                it("correctly serializes into the data class") {
+                test("correctly serializes into the data class") {
                     output shouldBe NamingStrategyTestData("value")
                 }
             }
         }
 
-        describe("parsing lists") {
+        context("parsing lists") {
             context("given a list of strings") {
                 val input = """
                     - thing1
@@ -589,7 +588,7 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input as a list") {
                     val result = Yaml.default.decodeFromString(ListSerializer(String.serializer()), input)
 
-                    it("deserializes it to the expected value") {
+                    test("deserializes it to the expected value") {
                         result shouldBe listOf("thing1", "thing2", "thing3")
                     }
                 }
@@ -597,13 +596,13 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input as a nullable list") {
                     val result = Yaml.default.decodeFromString(ListSerializer(String.serializer()).nullable, input)
 
-                    it("deserializes it to the expected value") {
+                    test("deserializes it to the expected value") {
                         result shouldBe listOf("thing1", "thing2", "thing3")
                     }
                 }
 
                 context("parsing that input with a serializer that uses YAML location information when throwing exceptions") {
-                    it("throws an exception with the correct location information") {
+                    test("throws an exception with the correct location information") {
                         val exception = shouldThrow<LocationInformationException> { Yaml.default.decodeFromString(ListSerializer(LocationThrowingSerializer), input) }
 
                         exception.asClue {
@@ -623,7 +622,7 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input as a list of integers") {
                     val result = Yaml.default.decodeFromString(ListSerializer(Int.serializer()), input)
 
-                    it("deserializes it to the expected value") {
+                    test("deserializes it to the expected value") {
                         result shouldBe listOf(123, 45, 6)
                     }
                 }
@@ -631,7 +630,7 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input as a list of longs") {
                     val result = Yaml.default.decodeFromString(ListSerializer(Long.serializer()), input)
 
-                    it("deserializes it to the expected value") {
+                    test("deserializes it to the expected value") {
                         result shouldBe listOf(123L, 45, 6)
                     }
                 }
@@ -639,7 +638,7 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input as a list of shorts") {
                     val result = Yaml.default.decodeFromString(ListSerializer(Short.serializer()), input)
 
-                    it("deserializes it to the expected value") {
+                    test("deserializes it to the expected value") {
                         result shouldBe listOf(123.toShort(), 45, 6)
                     }
                 }
@@ -647,7 +646,7 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input as a list of bytes") {
                     val result = Yaml.default.decodeFromString(ListSerializer(Byte.serializer()), input)
 
-                    it("deserializes it to the expected value") {
+                    test("deserializes it to the expected value") {
                         result shouldBe listOf(123.toByte(), 45, 6)
                     }
                 }
@@ -655,7 +654,7 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input as a list of doubles") {
                     val result = Yaml.default.decodeFromString(ListSerializer(Double.serializer()), input)
 
-                    it("deserializes it to the expected value") {
+                    test("deserializes it to the expected value") {
                         result shouldBe listOf(123.0, 45.0, 6.0)
                     }
                 }
@@ -663,7 +662,7 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input as a list of floats") {
                     val result = Yaml.default.decodeFromString(ListSerializer(Float.serializer()), input)
 
-                    it("deserializes it to the expected value") {
+                    test("deserializes it to the expected value") {
                         result shouldBe listOf(123.0f, 45.0f, 6.0f)
                     }
                 }
@@ -678,7 +677,7 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input as a list") {
                     val result = Yaml.default.decodeFromString(ListSerializer(Boolean.serializer()), input)
 
-                    it("deserializes it to the expected value") {
+                    test("deserializes it to the expected value") {
                         result shouldBe listOf(true, false)
                     }
                 }
@@ -693,7 +692,7 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input as a list") {
                     val result = Yaml.default.decodeFromString(ListSerializer(TestEnum.serializer()), input)
 
-                    it("deserializes it to the expected value") {
+                    test("deserializes it to the expected value") {
                         result shouldBe listOf(TestEnum.Value1, TestEnum.Value2)
                     }
                 }
@@ -708,7 +707,7 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input as a list") {
                     val result = Yaml.default.decodeFromString(ListSerializer(Char.serializer()), input)
 
-                    it("deserializes it to the expected value") {
+                    test("deserializes it to the expected value") {
                         result shouldBe listOf('a', 'b')
                     }
                 }
@@ -723,7 +722,7 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input as a list") {
                     val result = Yaml.default.decodeFromString(ListSerializer(String.serializer().nullable), input)
 
-                    it("deserializes it to the expected value") {
+                    test("deserializes it to the expected value") {
                         result shouldBe listOf("thing1", null)
                     }
                 }
@@ -738,7 +737,7 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input as a list") {
                     val result = Yaml.default.decodeFromString(ListSerializer(ListSerializer(String.serializer())), input)
 
-                    it("deserializes it to the expected value") {
+                    test("deserializes it to the expected value") {
                         result shouldBe
                             listOf(
                                 listOf("thing1", "thing2"),
@@ -757,7 +756,7 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input as a list") {
                     val result = Yaml.default.decodeFromString(ListSerializer(SimpleStructure.serializer()), input)
 
-                    it("deserializes it to the expected value") {
+                    test("deserializes it to the expected value") {
                         result shouldBe
                             listOf(
                                 SimpleStructure("thing1"),
@@ -768,7 +767,7 @@ class YamlReadingTest : DescribeSpec({
             }
         }
 
-        describe("parsing objects") {
+        context("parsing objects") {
             context("given some input representing an object with an optional value specified") {
                 val input = """
                     string: Alex
@@ -787,7 +786,7 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input") {
                     val result = Yaml.default.decodeFromString(ComplexStructure.serializer(), input)
 
-                    it("deserializes it to a Kotlin object") {
+                    test("deserializes it to a Kotlin object") {
                         result shouldBe
                             ComplexStructure(
                                 "Alex",
@@ -824,7 +823,7 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input") {
                     val result = Yaml.default.decodeFromString(ComplexStructure.serializer(), input)
 
-                    it("deserializes it to a Kotlin object") {
+                    test("deserializes it to a Kotlin object") {
                         result shouldBe
                             ComplexStructure(
                                 "Alex",
@@ -860,7 +859,7 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input") {
                     val result = Yaml.default.decodeFromString(ComplexStructure.serializer(), input)
 
-                    it("deserializes it to a Kotlin object") {
+                    test("deserializes it to a Kotlin object") {
                         result shouldBe
                             ComplexStructure(
                                 "Alex",
@@ -889,7 +888,7 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input") {
                     val result = Yaml.default.decodeFromString(Team.serializer(), input)
 
-                    it("deserializes it to a Kotlin object") {
+                    test("deserializes it to a Kotlin object") {
                         result shouldBe Team(listOf("Alex", "Jamie"))
                     }
                 }
@@ -906,7 +905,7 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input") {
                     val result = Yaml.default.decodeFromString(NestedObjects.serializer(), input)
 
-                    it("deserializes it to a Kotlin object") {
+                    test("deserializes it to a Kotlin object") {
                         result shouldBe NestedObjects(SimpleStructure("Alex"), SimpleStructure("Jamie"))
                     }
                 }
@@ -923,7 +922,7 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input") {
                     val result = Yaml.default.decodeFromString(NestedObjects.serializer(), input)
 
-                    it("deserializes it to a Kotlin object") {
+                    test("deserializes it to a Kotlin object") {
                         result shouldBe NestedObjects(SimpleStructure("Alex"), SimpleStructure("Jamie"))
                     }
                 }
@@ -938,13 +937,13 @@ class YamlReadingTest : DescribeSpec({
 
                 context("parsing that input as list") {
                     val result = Yaml.default.decodeFromString(ListSerializer(Int.serializer()), input)
-                    it("deserializes it to a list ignoring the tag") {
+                    test("deserializes it to a list ignoring the tag") {
                         result shouldBe listOf(5, 3)
                     }
                 }
 
                 context("parsing that input with a serializer that uses YAML location information when throwing exceptions") {
-                    it("throws an exception with the correct location information") {
+                    test("throws an exception with the correct location information") {
                         val exception = shouldThrow<LocationInformationException> { Yaml.default.decodeFromString(LocationThrowingSerializer, input) }
 
                         exception.asClue {
@@ -965,13 +964,13 @@ class YamlReadingTest : DescribeSpec({
                         MapSerializer(String.serializer(), String.serializer()),
                         input,
                     )
-                    it("deserializes it to a Map ignoring the tag") {
+                    test("deserializes it to a Map ignoring the tag") {
                         result shouldBe mapOf("foo" to "bar")
                     }
                 }
 
                 context("parsing that input with a serializer that uses YAML location information when throwing exceptions") {
-                    it("throws an exception with the correct location information") {
+                    test("throws an exception with the correct location information") {
                         val exception = shouldThrow<LocationInformationException> { Yaml.default.decodeFromString(LocationThrowingMapSerializer, input) }
 
                         exception.asClue {
@@ -995,7 +994,7 @@ class YamlReadingTest : DescribeSpec({
                 """.trimIndent()
 
                 context("parsing that input") {
-                    it("throws an appropriate exception") {
+                    test("throws an appropriate exception") {
                         val exception = shouldThrow<MissingRequiredPropertyException> { Yaml.default.decodeFromString(ComplexStructure.serializer(), input) }
 
                         exception.asClue {
@@ -1015,7 +1014,7 @@ class YamlReadingTest : DescribeSpec({
                 """.trimIndent()
 
                 context("parsing that input") {
-                    it("throws an appropriate exception") {
+                    test("throws an appropriate exception") {
                         val exception = shouldThrow<UnknownPropertyException> { Yaml.default.decodeFromString(ComplexStructure.serializer(), input) }
 
                         exception.asClue {
@@ -1035,7 +1034,7 @@ class YamlReadingTest : DescribeSpec({
                     val input = "oneTwoThree: something".trimIndent()
 
                     context("parsing that input") {
-                        it("throws an exception") {
+                        test("throws an exception") {
                             val exception = shouldThrow<UnknownPropertyException> {
                                 Yaml(
                                     configuration = YamlConfiguration(yamlNamingStrategy = YamlNamingStrategy.SnakeCase),
@@ -1058,7 +1057,7 @@ class YamlReadingTest : DescribeSpec({
                     val input = "firstPerson: something".trimIndent()
 
                     context("parsing that input") {
-                        it("throws an exception") {
+                        test("throws an exception") {
                             val exception = shouldThrow<UnknownPropertyException> {
                                 Yaml(
                                     configuration = YamlConfiguration(yamlNamingStrategy = YamlNamingStrategy.SnakeCase),
@@ -1094,7 +1093,7 @@ class YamlReadingTest : DescribeSpec({
                         val input = "$fieldName: xxx"
 
                         context("parsing that input") {
-                            it("throws an appropriate exception") {
+                            test("throws an appropriate exception") {
                                 val exception = shouldThrow<InvalidPropertyValueException> { Yaml.default.decodeFromString(ComplexStructure.serializer(), input) }
 
                                 exception.asClue {
@@ -1115,7 +1114,7 @@ class YamlReadingTest : DescribeSpec({
                 val input = "name: null"
 
                 context("parsing that input") {
-                    it("throws an appropriate exception") {
+                    test("throws an appropriate exception") {
                         val exception = shouldThrow<InvalidPropertyValueException> { Yaml.default.decodeFromString(SimpleStructure.serializer(), input) }
 
                         exception.asClue {
@@ -1134,7 +1133,7 @@ class YamlReadingTest : DescribeSpec({
                 val input = "firstPerson: null"
 
                 context("parsing that input") {
-                    it("throws an appropriate exception") {
+                    test("throws an appropriate exception") {
                         val exception = shouldThrow<InvalidPropertyValueException> { Yaml.default.decodeFromString(NestedObjects.serializer(), input) }
 
                         exception.asClue {
@@ -1156,7 +1155,7 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input") {
                     val result = Yaml.default.decodeFromString(NullableNestedObject.serializer(), input)
 
-                    it("deserializes it to a Kotlin object") {
+                    test("deserializes it to a Kotlin object") {
                         result shouldBe NullableNestedObject(null)
                     }
                 }
@@ -1166,7 +1165,7 @@ class YamlReadingTest : DescribeSpec({
                 val input = "members: null"
 
                 context("parsing that input") {
-                    it("throws an appropriate exception") {
+                    test("throws an appropriate exception") {
                         val exception = shouldThrow<InvalidPropertyValueException> { Yaml.default.decodeFromString(Team.serializer(), input) }
 
                         exception.asClue {
@@ -1187,7 +1186,7 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input") {
                     val result = Yaml.default.decodeFromString(NullableNestedList.serializer(), input)
 
-                    it("deserializes it to a Kotlin object") {
+                    test("deserializes it to a Kotlin object") {
                         result shouldBe NullableNestedList(null)
                     }
                 }
@@ -1197,7 +1196,7 @@ class YamlReadingTest : DescribeSpec({
                 val input = "value: something"
 
                 context("parsing that input with a serializer that uses YAML location information when throwing exceptions") {
-                    it("throws an exception with the correct location information") {
+                    test("throws an exception with the correct location information") {
                         val exception = shouldThrow<LocationInformationException> { Yaml.default.decodeFromString(StructureWithLocationThrowingSerializer.serializer(), input) }
 
                         exception.asClue {
@@ -1216,7 +1215,7 @@ class YamlReadingTest : DescribeSpec({
                 context("parsing that input") {
                     val result = Yaml.default.decodeFromString(MapSerializer(String.serializer(), String.serializer()), input)
 
-                    it("deserializes it to a Kotlin map") {
+                    test("deserializes it to a Kotlin map") {
                         result shouldBe
                             mapOf(
                                 "SOME_ENV_VAR" to "somevalue",
@@ -1226,7 +1225,7 @@ class YamlReadingTest : DescribeSpec({
                 }
 
                 context("parsing that input with a serializer for the key that uses YAML location information when throwing exceptions") {
-                    it("throws an exception with the correct location information") {
+                    test("throws an exception with the correct location information") {
                         val exception = shouldThrow<LocationInformationException> { Yaml.default.decodeFromString(MapSerializer(LocationThrowingSerializer, String.serializer()), input) }
 
                         exception.asClue {
@@ -1236,7 +1235,7 @@ class YamlReadingTest : DescribeSpec({
                 }
 
                 context("parsing that input with a serializer for the value that uses YAML location information when throwing exceptions") {
-                    it("throws an exception with the correct location information") {
+                    test("throws an exception with the correct location information") {
                         val exception = shouldThrow<LocationInformationException> { Yaml.default.decodeFromString(MapSerializer(String.serializer(), LocationThrowingSerializer), input) }
 
                         exception.asClue {
@@ -1257,7 +1256,7 @@ class YamlReadingTest : DescribeSpec({
                     val configuration = YamlConfiguration(extensionDefinitionPrefix = ".", allowAnchorsAndAliases = false)
                     val yaml = Yaml(configuration = configuration)
 
-                    it("throws an appropriate exception") {
+                    test("throws an appropriate exception") {
                         val exception = shouldThrow<ForbiddenAnchorOrAliasException> { yaml.decodeFromString(SimpleStructure.serializer(), input) }
 
                         exception.asClue {
@@ -1273,7 +1272,7 @@ class YamlReadingTest : DescribeSpec({
                     val yaml = Yaml(configuration = configuration)
                     val result = yaml.decodeFromString(SimpleStructure.serializer(), input)
 
-                    it("deserializes it to a Kotlin object, replacing the reference to the extension with the extension") {
+                    test("deserializes it to a Kotlin object, replacing the reference to the extension with the extension") {
                         result shouldBe SimpleStructure("Jamie")
                     }
                 }
@@ -1290,7 +1289,7 @@ class YamlReadingTest : DescribeSpec({
                     val yaml = Yaml(configuration = configuration)
 
                     context("parsing that input") {
-                        it("throws an appropriate exception") {
+                        test("throws an appropriate exception") {
                             val exception = shouldThrow<UnknownPropertyException> { yaml.decodeFromString(SimpleStructure.serializer(), input) }
 
                             exception.asClue {
@@ -1308,7 +1307,7 @@ class YamlReadingTest : DescribeSpec({
                     val yaml = Yaml(configuration = configuration)
 
                     context("parsing that input") {
-                        it("ignores the extra field and returns a deserialised object") {
+                        test("ignores the extra field and returns a deserialised object") {
                             yaml.decodeFromString(SimpleStructure.serializer(), input) shouldBe SimpleStructure("Blah Blahson")
                         }
                     }
@@ -1322,14 +1321,14 @@ class YamlReadingTest : DescribeSpec({
 
                 val result = Yaml.default.decodeFromString(Database.serializer().nullable, input)
 
-                it("deserializes it to the expected object") {
+                test("deserializes it to the expected object") {
                     result shouldBe Database("db.test.com")
                 }
             }
         }
 
-        describe("parsing polymorphic values") {
-            describe("given tags are used to store the type information") {
+        context("parsing polymorphic values") {
+            context("given tags are used to store the type information") {
                 val polymorphicYaml = Yaml(serializersModule = polymorphicModule, configuration = YamlConfiguration(polymorphismStyle = PolymorphismStyle.Tag))
 
                 context("given some input where the value should be a sealed class") {
@@ -1341,7 +1340,7 @@ class YamlReadingTest : DescribeSpec({
                     context("parsing that input") {
                         val result = polymorphicYaml.decodeFromString(TestSealedStructure.serializer(), input)
 
-                        it("deserializes it to a Kotlin object") {
+                        test("deserializes it to a Kotlin object") {
                             result shouldBe TestSealedStructure.SimpleSealedString("asdfg")
                         }
                     }
@@ -1349,7 +1348,7 @@ class YamlReadingTest : DescribeSpec({
                     context("parsing that input as map") {
                         val result = polymorphicYaml.decodeFromString(MapSerializer(String.serializer(), String.serializer()), input)
 
-                        it("deserializes it to a map ignoring the tag") {
+                        test("deserializes it to a map ignoring the tag") {
                             result shouldBe mapOf("value" to "asdfg")
                         }
                     }
@@ -1362,7 +1361,7 @@ class YamlReadingTest : DescribeSpec({
                     """.trimIndent()
 
                     context("parsing that input") {
-                        it("throws an appropriate exception") {
+                        test("throws an appropriate exception") {
                             val exception = shouldThrow<MissingRequiredPropertyException> { polymorphicYaml.decodeFromString(TestSealedStructure.serializer(), input) }
 
                             exception.asClue {
@@ -1384,7 +1383,7 @@ class YamlReadingTest : DescribeSpec({
                     context("parsing that input") {
                         val result = polymorphicYaml.decodeFromString(PolymorphicSerializer(UnwrappedInterface::class), input)
 
-                        it("deserializes it to a Kotlin object") {
+                        test("deserializes it to a Kotlin object") {
                             result shouldBe UnwrappedString("asdfg")
                         }
                     }
@@ -1392,7 +1391,7 @@ class YamlReadingTest : DescribeSpec({
                     context("parsing that input as a string") {
                         val result = polymorphicYaml.decodeFromString(String.serializer(), input)
 
-                        it("deserializes it to a string ignoring the tag") {
+                        test("deserializes it to a string ignoring the tag") {
                             result shouldBe "asdfg"
                         }
                     }
@@ -1407,7 +1406,7 @@ class YamlReadingTest : DescribeSpec({
                     context("parsing that input") {
                         val result = polymorphicYaml.decodeFromString(PolymorphicSerializer(UnsealedClass::class), input)
 
-                        it("deserializes it to a Kotlin object") {
+                        test("deserializes it to a Kotlin object") {
                             result shouldBe UnsealedString("asdfg")
                         }
                     }
@@ -1415,7 +1414,7 @@ class YamlReadingTest : DescribeSpec({
                     context("parsing that input as map") {
                         val result = polymorphicYaml.decodeFromString(MapSerializer(String.serializer(), String.serializer()), input)
 
-                        it("deserializes it to a map ignoring the tag") {
+                        test("deserializes it to a map ignoring the tag") {
                             result shouldBe mapOf("value" to "asdfg")
                         }
                     }
@@ -1430,7 +1429,7 @@ class YamlReadingTest : DescribeSpec({
                     context("parsing that input") {
                         val result = polymorphicYaml.decodeFromString(SealedWrapper.serializer(), input)
 
-                        it("deserializes it to a Kotlin object") {
+                        test("deserializes it to a Kotlin object") {
                             result shouldBe SealedWrapper(TestSealedStructure.SimpleSealedString("asdfg"))
                         }
                     }
@@ -1438,7 +1437,7 @@ class YamlReadingTest : DescribeSpec({
                     context("parsing that input as map") {
                         val result = polymorphicYaml.decodeFromString(MapSerializer(String.serializer(), MapSerializer(String.serializer(), String.serializer())), input)
 
-                        it("deserializes it to a map ignoring the tag") {
+                        test("deserializes it to a map ignoring the tag") {
                             result shouldBe mapOf("element" to mapOf("value" to "asdfg"))
                         }
                     }
@@ -1452,7 +1451,7 @@ class YamlReadingTest : DescribeSpec({
                     context("parsing that input") {
                         val result = polymorphicYaml.decodeFromString(PolymorphicWrapper.serializer(), input)
 
-                        it("deserializes it to a Kotlin object") {
+                        test("deserializes it to a Kotlin object") {
                             result shouldBe PolymorphicWrapper(UnwrappedInt(42))
                         }
                     }
@@ -1473,7 +1472,7 @@ class YamlReadingTest : DescribeSpec({
                     context("parsing that input") {
                         val result = polymorphicYaml.decodeFromString(ListSerializer(TestSealedStructure.serializer()), input)
 
-                        it("deserializes it to a Kotlin object") {
+                        test("deserializes it to a Kotlin object") {
                             result shouldBe
                                 listOf(
                                     TestSealedStructure.SimpleSealedString(null),
@@ -1492,7 +1491,7 @@ class YamlReadingTest : DescribeSpec({
                     """.trimIndent()
 
                     context("parsing that input") {
-                        it("throws an exception with the correct location information") {
+                        test("throws an exception with the correct location information") {
                             val exception = shouldThrow<InvalidPropertyValueException> { polymorphicYaml.decodeFromString(SealedWrapper.serializer(), input) }
 
                             exception.asClue {
@@ -1512,7 +1511,7 @@ class YamlReadingTest : DescribeSpec({
                     """.trimIndent()
 
                     context("parsing that input") {
-                        it("throws an exception with the correct location information") {
+                        test("throws an exception with the correct location information") {
                             val exception = shouldThrow<InvalidPropertyValueException> { polymorphicYaml.decodeFromString(PolymorphicWrapper.serializer(), input) }
 
                             exception.asClue {
@@ -1532,7 +1531,7 @@ class YamlReadingTest : DescribeSpec({
                     """.trimIndent()
 
                     context("parsing that input") {
-                        it("throws an exception with the correct location information") {
+                        test("throws an exception with the correct location information") {
                             val exception = shouldThrow<InvalidPropertyValueException> { polymorphicYaml.decodeFromString(PolymorphicWrapper.serializer(), input) }
 
                             exception.asClue {
@@ -1552,7 +1551,7 @@ class YamlReadingTest : DescribeSpec({
                     """.trimIndent()
 
                     context("parsing that input") {
-                        it("throws an exception with the correct location information") {
+                        test("throws an exception with the correct location information") {
                             val exception = shouldThrow<UnknownPolymorphicTypeException> { polymorphicYaml.decodeFromString(PolymorphicSerializer(UnsealedClass::class), input) }
 
                             exception.asClue {
@@ -1573,7 +1572,7 @@ class YamlReadingTest : DescribeSpec({
                     """.trimIndent()
 
                     context("parsing that input") {
-                        it("throws an exception with the correct location information") {
+                        test("throws an exception with the correct location information") {
                             val exception = shouldThrow<UnknownPolymorphicTypeException> { polymorphicYaml.decodeFromString(TestSealedStructure.serializer(), input) }
 
                             exception.asClue {
@@ -1594,7 +1593,7 @@ class YamlReadingTest : DescribeSpec({
                     """.trimIndent()
 
                     context("parsing that input") {
-                        it("throws an exception with the correct location information") {
+                        test("throws an exception with the correct location information") {
                             val exception = shouldThrow<UnknownPolymorphicTypeException> { polymorphicYaml.decodeFromString(TestSealedStructure.serializer(), input) }
 
                             exception.asClue {
@@ -1610,7 +1609,7 @@ class YamlReadingTest : DescribeSpec({
                 }
             }
 
-            describe("given a property is used to store the type information") {
+            context("given a property is used to store the type information") {
                 val polymorphicYaml = Yaml(serializersModule = polymorphicModule, configuration = YamlConfiguration(polymorphismStyle = PolymorphismStyle.Property))
 
                 context("given some input where the value should be a sealed class") {
@@ -1622,7 +1621,7 @@ class YamlReadingTest : DescribeSpec({
                     context("parsing that input") {
                         val result = polymorphicYaml.decodeFromString(TestSealedStructure.serializer(), input)
 
-                        it("deserializes it to a Kotlin object") {
+                        test("deserializes it to a Kotlin object") {
                             result shouldBe TestSealedStructure.SimpleSealedString("asdfg")
                         }
                     }
@@ -1630,7 +1629,7 @@ class YamlReadingTest : DescribeSpec({
                     context("parsing that input as map") {
                         val result = polymorphicYaml.decodeFromString(MapSerializer(String.serializer(), String.serializer()), input)
 
-                        it("deserializes it to a map including the type") {
+                        test("deserializes it to a map including the type") {
                             result shouldBe mapOf("type" to "sealedString", "value" to "asdfg")
                         }
                     }
@@ -1645,7 +1644,7 @@ class YamlReadingTest : DescribeSpec({
                     context("parsing that input") {
                         val result = polymorphicYaml.decodeFromString(PolymorphicSerializer(UnsealedClass::class), input)
 
-                        it("deserializes it to a Kotlin object") {
+                        test("deserializes it to a Kotlin object") {
                             result shouldBe UnsealedString("asdfg")
                         }
                     }
@@ -1653,7 +1652,7 @@ class YamlReadingTest : DescribeSpec({
                     context("parsing that input as map") {
                         val result = polymorphicYaml.decodeFromString(MapSerializer(String.serializer(), String.serializer()), input)
 
-                        it("deserializes it to a map ignoring the tag") {
+                        test("deserializes it to a map ignoring the tag") {
                             result shouldBe mapOf("type" to "unsealedString", "value" to "asdfg")
                         }
                     }
@@ -1669,7 +1668,7 @@ class YamlReadingTest : DescribeSpec({
                     context("parsing that input") {
                         val result = polymorphicYaml.decodeFromString(SealedWrapper.serializer(), input)
 
-                        it("deserializes it to a Kotlin object") {
+                        test("deserializes it to a Kotlin object") {
                             result shouldBe SealedWrapper(TestSealedStructure.SimpleSealedString("asdfg"))
                         }
                     }
@@ -1677,7 +1676,7 @@ class YamlReadingTest : DescribeSpec({
                     context("parsing that input as map") {
                         val result = polymorphicYaml.decodeFromString(MapSerializer(String.serializer(), MapSerializer(String.serializer(), String.serializer())), input)
 
-                        it("deserializes it to a map ignoring the tag") {
+                        test("deserializes it to a map ignoring the tag") {
                             result shouldBe mapOf("element" to mapOf("type" to "sealedString", "value" to "asdfg"))
                         }
                     }
@@ -1689,7 +1688,7 @@ class YamlReadingTest : DescribeSpec({
                     """.trimIndent()
 
                     context("parsing that input") {
-                        it("throws an exception with the correct location information") {
+                        test("throws an exception with the correct location information") {
                             val exception = shouldThrow<MissingRequiredPropertyException> { polymorphicYaml.decodeFromString(TestSealedStructure.serializer(), input) }
 
                             exception.asClue {
@@ -1716,7 +1715,7 @@ class YamlReadingTest : DescribeSpec({
                         """.trimIndent()
 
                         context("parsing that input") {
-                            it("throws an exception with the correct location information") {
+                            test("throws an exception with the correct location information") {
                                 val exception = shouldThrow<InvalidPropertyValueException> { polymorphicYaml.decodeFromString(TestSealedStructure.serializer(), input) }
 
                                 exception.asClue {
@@ -1747,7 +1746,7 @@ class YamlReadingTest : DescribeSpec({
                     context("parsing that input") {
                         val result = polymorphicYaml.decodeFromString(ListSerializer(TestSealedStructure.serializer()), input)
 
-                        it("deserializes it to a Kotlin object") {
+                        test("deserializes it to a Kotlin object") {
                             result shouldBe
                                 listOf(
                                     TestSealedStructure.SimpleSealedString(null),
@@ -1766,7 +1765,7 @@ class YamlReadingTest : DescribeSpec({
                     """.trimIndent()
 
                     context("parsing that input") {
-                        it("throws an exception with the correct location information") {
+                        test("throws an exception with the correct location information") {
                             val exception = shouldThrow<UnknownPolymorphicTypeException> { polymorphicYaml.decodeFromString(PolymorphicSerializer(UnsealedClass::class), input) }
 
                             exception.asClue {
@@ -1788,7 +1787,7 @@ class YamlReadingTest : DescribeSpec({
                     """.trimIndent()
 
                     context("parsing that input") {
-                        it("throws an exception with the correct location information") {
+                        test("throws an exception with the correct location information") {
                             val exception = shouldThrow<UnknownPolymorphicTypeException> { polymorphicYaml.decodeFromString(TestSealedStructure.serializer(), input) }
 
                             exception.asClue {
@@ -1813,14 +1812,14 @@ class YamlReadingTest : DescribeSpec({
                     context("parsing that input") {
                         val result = polymorphicYaml.decodeFromString(TestSealedStructure.serializer(), input)
 
-                        it("uses the type from the property and ignores the tag") {
+                        test("uses the type from the property and ignores the tag") {
                             result shouldBe TestSealedStructure.SimpleSealedString("asdfg")
                         }
                     }
                 }
             }
 
-            describe("given a custom property name is used to store the type information") {
+            context("given a custom property name is used to store the type information") {
                 val polymorphicYaml = Yaml(serializersModule = polymorphicModule, configuration = YamlConfiguration(polymorphismStyle = PolymorphismStyle.Property, polymorphismPropertyName = "kind"))
 
                 context("given some input where the value should be a sealed class") {
@@ -1832,7 +1831,7 @@ class YamlReadingTest : DescribeSpec({
                     context("parsing that input") {
                         val result = polymorphicYaml.decodeFromString(TestSealedStructure.serializer(), input)
 
-                        it("deserializes it to a Kotlin object") {
+                        test("deserializes it to a Kotlin object") {
                             result shouldBe TestSealedStructure.SimpleSealedString("asdfg")
                         }
                     }
@@ -1840,7 +1839,7 @@ class YamlReadingTest : DescribeSpec({
                     context("parsing that input as map") {
                         val result = polymorphicYaml.decodeFromString(MapSerializer(String.serializer(), String.serializer()), input)
 
-                        it("deserializes it to a map including the type") {
+                        test("deserializes it to a map including the type") {
                             result shouldBe mapOf("kind" to "sealedString", "value" to "asdfg")
                         }
                     }
@@ -1855,7 +1854,7 @@ class YamlReadingTest : DescribeSpec({
                     context("parsing that input") {
                         val result = polymorphicYaml.decodeFromString(PolymorphicSerializer(UnsealedClass::class), input)
 
-                        it("deserializes it to a Kotlin object") {
+                        test("deserializes it to a Kotlin object") {
                             result shouldBe UnsealedString("asdfg")
                         }
                     }
@@ -1863,7 +1862,7 @@ class YamlReadingTest : DescribeSpec({
                     context("parsing that input as map") {
                         val result = polymorphicYaml.decodeFromString(MapSerializer(String.serializer(), String.serializer()), input)
 
-                        it("deserializes it to a map ignoring the tag") {
+                        test("deserializes it to a map ignoring the tag") {
                             result shouldBe mapOf("kind" to "unsealedString", "value" to "asdfg")
                         }
                     }
@@ -1879,7 +1878,7 @@ class YamlReadingTest : DescribeSpec({
                     context("parsing that input") {
                         val result = polymorphicYaml.decodeFromString(SealedWrapper.serializer(), input)
 
-                        it("deserializes it to a Kotlin object") {
+                        test("deserializes it to a Kotlin object") {
                             result shouldBe SealedWrapper(TestSealedStructure.SimpleSealedString("asdfg"))
                         }
                     }
@@ -1887,7 +1886,7 @@ class YamlReadingTest : DescribeSpec({
                     context("parsing that input as map") {
                         val result = polymorphicYaml.decodeFromString(MapSerializer(String.serializer(), MapSerializer(String.serializer(), String.serializer())), input)
 
-                        it("deserializes it to a map ignoring the tag") {
+                        test("deserializes it to a map ignoring the tag") {
                             result shouldBe mapOf("element" to mapOf("kind" to "sealedString", "value" to "asdfg"))
                         }
                     }
@@ -1899,7 +1898,7 @@ class YamlReadingTest : DescribeSpec({
                     """.trimIndent()
 
                     context("parsing that input") {
-                        it("throws an exception with the correct location information") {
+                        test("throws an exception with the correct location information") {
                             val exception = shouldThrow<MissingRequiredPropertyException> { polymorphicYaml.decodeFromString(TestSealedStructure.serializer(), input) }
 
                             exception.asClue {
@@ -1926,7 +1925,7 @@ class YamlReadingTest : DescribeSpec({
                         """.trimIndent()
 
                         context("parsing that input") {
-                            it("throws an exception with the correct location information") {
+                            test("throws an exception with the correct location information") {
                                 val exception = shouldThrow<InvalidPropertyValueException> { polymorphicYaml.decodeFromString(TestSealedStructure.serializer(), input) }
 
                                 exception.asClue {
@@ -1957,7 +1956,7 @@ class YamlReadingTest : DescribeSpec({
                     context("parsing that input") {
                         val result = polymorphicYaml.decodeFromString(ListSerializer(TestSealedStructure.serializer()), input)
 
-                        it("deserializes it to a Kotlin object") {
+                        test("deserializes it to a Kotlin object") {
                             result shouldBe
                                 listOf(
                                     TestSealedStructure.SimpleSealedString(null),
@@ -1976,7 +1975,7 @@ class YamlReadingTest : DescribeSpec({
                     """.trimIndent()
 
                     context("parsing that input") {
-                        it("throws an exception with the correct location information") {
+                        test("throws an exception with the correct location information") {
                             val exception = shouldThrow<UnknownPolymorphicTypeException> { polymorphicYaml.decodeFromString(PolymorphicSerializer(UnsealedClass::class), input) }
 
                             exception.asClue {
@@ -1998,7 +1997,7 @@ class YamlReadingTest : DescribeSpec({
                     """.trimIndent()
 
                     context("parsing that input") {
-                        it("throws an exception with the correct location information") {
+                        test("throws an exception with the correct location information") {
                             val exception = shouldThrow<UnknownPolymorphicTypeException> { polymorphicYaml.decodeFromString(TestSealedStructure.serializer(), input) }
 
                             exception.asClue {
@@ -2023,14 +2022,14 @@ class YamlReadingTest : DescribeSpec({
                     context("parsing that input") {
                         val result = polymorphicYaml.decodeFromString(TestSealedStructure.serializer(), input)
 
-                        it("uses the type from the property and ignores the tag") {
+                        test("uses the type from the property and ignores the tag") {
                             result shouldBe TestSealedStructure.SimpleSealedString("asdfg")
                         }
                     }
                 }
             }
 
-            describe("given polymorphic inputs when PolymorphismStyle.None is used") {
+            context("given polymorphic inputs when PolymorphismStyle.None is used") {
                 val polymorphicYaml = Yaml(serializersModule = polymorphicModule, configuration = YamlConfiguration(polymorphismStyle = PolymorphismStyle.None))
 
                 context("given tagged input") {
@@ -2040,7 +2039,7 @@ class YamlReadingTest : DescribeSpec({
                     """.trimIndent()
 
                     context("parsing that input") {
-                        it("throws an appropriate exception") {
+                        test("throws an appropriate exception") {
                             val exception = shouldThrow<IncorrectTypeException> { polymorphicYaml.decodeFromString(TestSealedStructure.serializer(), input) }
 
                             exception.asClue {
@@ -2059,7 +2058,7 @@ class YamlReadingTest : DescribeSpec({
                     """.trimIndent()
 
                     context("parsing that input") {
-                        it("throws an appropriate exception") {
+                        test("throws an appropriate exception") {
                             val exception = shouldThrow<IncorrectTypeException> { polymorphicYaml.decodeFromString(TestSealedStructure.serializer(), input) }
 
                             exception.asClue {
@@ -2074,8 +2073,8 @@ class YamlReadingTest : DescribeSpec({
             }
         }
 
-        describe("parsing values with a dynamically installed serializer") {
-            describe("parsing a literal with a contextual serializer") {
+        context("parsing values with a dynamically installed serializer") {
+            context("parsing a literal with a contextual serializer") {
                 val contextSerializer = object : KSerializer<Inner> {
                     override val descriptor: SerialDescriptor
                         get() = String.serializer().descriptor
@@ -2093,12 +2092,12 @@ class YamlReadingTest : DescribeSpec({
 
                 val result = parser.decodeFromString(Container.serializer(), input)
 
-                it("deserializes it using the dynamically installed serializer") {
+                test("deserializes it using the dynamically installed serializer") {
                     result shouldBe Container(Inner("from context serializer"))
                 }
             }
 
-            describe("parsing a class with a contextual serializer") {
+            context("parsing a class with a contextual serializer") {
                 val contextSerializer = object : KSerializer<Inner> {
                     override val descriptor = buildClassSerialDescriptor("Inner") {
                         element("thing", String.serializer().descriptor)
@@ -2126,12 +2125,12 @@ class YamlReadingTest : DescribeSpec({
 
                 val result = parser.decodeFromString(Container.serializer(), input)
 
-                it("deserializes it using the dynamically installed serializer") {
+                test("deserializes it using the dynamically installed serializer") {
                     result shouldBe Container(Inner("this is the input, from context serializer"))
                 }
             }
 
-            describe("parsing a map with a contextual serializer") {
+            context("parsing a map with a contextual serializer") {
                 val contextSerializer = object : KSerializer<Inner> {
                     override val descriptor = buildSerialDescriptor("Inner", StructureKind.MAP) {
                         element("key", String.serializer().descriptor)
@@ -2163,13 +2162,13 @@ class YamlReadingTest : DescribeSpec({
 
                 val result = parser.decodeFromString(Container.serializer(), input)
 
-                it("deserializes it using the dynamically installed serializer") {
+                test("deserializes it using the dynamically installed serializer") {
                     result shouldBe Container(Inner("thing: this is the input, from context serializer"))
                 }
             }
         }
 
-        describe("parsing values with mismatched types") {
+        context("parsing values with mismatched types") {
             data class Scenario(
                 val description: String,
                 val serializer: KSerializer<out Any?>,
@@ -2195,7 +2194,7 @@ class YamlReadingTest : DescribeSpec({
                     val input = "- thing"
 
                     context("parsing that input as $description") {
-                        it("throws an exception with the correct location information") {
+                        test("throws an exception with the correct location information") {
                             val exception = shouldThrow<IncorrectTypeException> { Yaml.default.decodeFromString(serializer, input) }
 
                             exception.asClue {
@@ -2214,7 +2213,7 @@ class YamlReadingTest : DescribeSpec({
                             - some_value
                     """.trimIndent()
 
-                    it("throws an exception with the correct location information") {
+                    test("throws an exception with the correct location information") {
                         val exception = shouldThrow<InvalidPropertyValueException> { Yaml.default.decodeFromString(MapSerializer(String.serializer(), String.serializer()), input) }
 
                         exception.asClue {
@@ -2232,7 +2231,7 @@ class YamlReadingTest : DescribeSpec({
                             - some_value
                     """.trimIndent()
 
-                    it("throws an exception with the correct location information") {
+                    test("throws an exception with the correct location information") {
                         val exception = shouldThrow<InvalidPropertyValueException> { Yaml.default.decodeFromString(ComplexStructure.serializer(), input) }
 
                         exception.asClue {
@@ -2249,7 +2248,7 @@ class YamlReadingTest : DescribeSpec({
                         - [ some_value ]
                     """.trimIndent()
 
-                    it("throws an exception with the correct location information") {
+                    test("throws an exception with the correct location information") {
                         val exception = shouldThrow<IncorrectTypeException> { Yaml.default.decodeFromString(ListSerializer(String.serializer()), input) }
 
                         exception.asClue {
@@ -2280,7 +2279,7 @@ class YamlReadingTest : DescribeSpec({
                     val input = "key: value"
 
                     context("parsing that input as $description") {
-                        it("throws an exception with the correct location information") {
+                        test("throws an exception with the correct location information") {
                             val exception = shouldThrow<IncorrectTypeException> { Yaml.default.decodeFromString(serializer, input) }
 
                             exception.asClue {
@@ -2299,7 +2298,7 @@ class YamlReadingTest : DescribeSpec({
                             some_key: some_value
                     """.trimIndent()
 
-                    it("throws an exception with the correct location information") {
+                    test("throws an exception with the correct location information") {
                         val exception = shouldThrow<InvalidPropertyValueException> { Yaml.default.decodeFromString(MapSerializer(String.serializer(), String.serializer()), input) }
 
                         exception.asClue {
@@ -2317,7 +2316,7 @@ class YamlReadingTest : DescribeSpec({
                             some_key: some_value
                     """.trimIndent()
 
-                    it("throws an exception with the correct location information") {
+                    test("throws an exception with the correct location information") {
                         val exception = shouldThrow<InvalidPropertyValueException> { Yaml.default.decodeFromString(ComplexStructure.serializer(), input) }
 
                         exception.asClue {
@@ -2334,7 +2333,7 @@ class YamlReadingTest : DescribeSpec({
                         - some_key: some_value
                     """.trimIndent()
 
-                    it("throws an exception with the correct location information") {
+                    test("throws an exception with the correct location information") {
                         val exception = shouldThrow<IncorrectTypeException> { Yaml.default.decodeFromString(ListSerializer(String.serializer()), input) }
 
                         exception.asClue {
@@ -2356,7 +2355,7 @@ class YamlReadingTest : DescribeSpec({
                     val input = "blah"
 
                     context("parsing that input as $description") {
-                        it("throws an exception with the correct location information") {
+                        test("throws an exception with the correct location information") {
                             val exception = shouldThrow<IncorrectTypeException> { Yaml.default.decodeFromString(serializer, input) }
 
                             exception.asClue {
@@ -2374,7 +2373,7 @@ class YamlReadingTest : DescribeSpec({
                         key: some_value
                     """.trimIndent()
 
-                    it("throws an exception with the correct location information") {
+                    test("throws an exception with the correct location information") {
                         val exception = shouldThrow<InvalidPropertyValueException> { Yaml.default.decodeFromString(MapSerializer(String.serializer(), ListSerializer(String.serializer())), input) }
 
                         exception.asClue {
@@ -2391,7 +2390,7 @@ class YamlReadingTest : DescribeSpec({
                         members: some_value
                     """.trimIndent()
 
-                    it("throws an exception with the correct location information") {
+                    test("throws an exception with the correct location information") {
                         val exception = shouldThrow<InvalidPropertyValueException> { Yaml.default.decodeFromString(Team.serializer(), input) }
 
                         exception.asClue {
@@ -2408,7 +2407,7 @@ class YamlReadingTest : DescribeSpec({
                         - some_value
                     """.trimIndent()
 
-                    it("throws an exception with the correct location information") {
+                    test("throws an exception with the correct location information") {
                         val exception = shouldThrow<IncorrectTypeException> { Yaml.default.decodeFromString(ListSerializer((ListSerializer(String.serializer()))), input) }
 
                         exception.asClue {
@@ -2422,7 +2421,7 @@ class YamlReadingTest : DescribeSpec({
             }
         }
 
-        describe("parsing values with a contextual serializer") {
+        context("parsing values with a contextual serializer") {
             mapOf(
                 "scalar" to "2",
                 "list" to "[ thing ]",
@@ -2432,7 +2431,7 @@ class YamlReadingTest : DescribeSpec({
                     context("parsing that input using a contextual serializer at the top level") {
                         val result = Yaml.default.decodeFromString(ContextualSerializer, input)
 
-                        it("the serializer receives the top-level object") {
+                        test("the serializer receives the top-level object") {
                             result shouldBe description
                         }
                     }
@@ -2440,14 +2439,14 @@ class YamlReadingTest : DescribeSpec({
                     context("parsing that input using a contextual serializer nested within an object") {
                         val result = Yaml.default.decodeFromString(ObjectWithNestedContextualSerializer.serializer(), "thing: $input")
 
-                        it("the serializer receives the correct object") {
+                        test("the serializer receives the correct object") {
                             result shouldBe ObjectWithNestedContextualSerializer(description)
                         }
                     }
                 }
             }
 
-            describe("given the contextual serializer attempts to begin a structure that does not match the input") {
+            context("given the contextual serializer attempts to begin a structure that does not match the input") {
                 context("given the input is a map") {
                     val input = "a: b"
 
@@ -2456,7 +2455,7 @@ class YamlReadingTest : DescribeSpec({
                         StructureKind.LIST to "a list",
                     ).forEach { (kind, description) ->
                         context("attempting to begin $description") {
-                            it("throws an exception with the correct location information") {
+                            test("throws an exception with the correct location information") {
                                 val exception = shouldThrow<IncorrectTypeException> { Yaml.default.decodeFromString(ContextualSerializerThatAttemptsToDeserializeIncorrectType(kind), input) }
 
                                 exception.asClue {
@@ -2480,7 +2479,7 @@ class YamlReadingTest : DescribeSpec({
                         PrimitiveKind.STRING to "a string",
                     ).forEach { (kind, description) ->
                         context("attempting to begin $kind") {
-                            it("throws an exception with the correct location information") {
+                            test("throws an exception with the correct location information") {
                                 val exception = shouldThrow<IncorrectTypeException> { Yaml.default.decodeFromString(ContextualSerializerThatAttemptsToDeserializeIncorrectType(kind), input) }
 
                                 exception.asClue {
@@ -2504,7 +2503,7 @@ class YamlReadingTest : DescribeSpec({
                         StructureKind.LIST to "a list",
                     ).forEach { (kind, description) ->
                         context("attempting to begin $kind") {
-                            it("throws an exception with the correct location information") {
+                            test("throws an exception with the correct location information") {
                                 val exception = shouldThrow<IncorrectTypeException> { Yaml.default.decodeFromString(ContextualSerializerThatAttemptsToDeserializeIncorrectType(kind), input) }
 
                                 exception.asClue {
@@ -2519,7 +2518,7 @@ class YamlReadingTest : DescribeSpec({
                 }
             }
 
-            describe("decoding from a YamlNode") {
+            context("decoding from a YamlNode") {
                 val input = """
                     keyA:
                         host: A
@@ -2544,12 +2543,12 @@ class YamlReadingTest : DescribeSpec({
                 val parser = Yaml.default
                 val result = parser.decodeFromString(mapAsListSerializer, input)
 
-                it("decodes the map value as a list using the YamlNode") {
+                test("decodes the map value as a list using the YamlNode") {
                     result shouldBe listOf(Database("A"), Database("B"))
                 }
             }
 
-            describe("decoding from a YamlNode at a non-root node") {
+            context("decoding from a YamlNode at a non-root node") {
                 val input = """
                     databaseListing:
                         keyA:
@@ -2561,7 +2560,7 @@ class YamlReadingTest : DescribeSpec({
                 val parser = Yaml.default
                 val result = parser.decodeFromString(ServerConfig.serializer(), input)
 
-                it("decodes the map value as a list using the YamlNode") {
+                test("decodes the map value as a list using the YamlNode") {
                     result shouldBe ServerConfig(DatabaseListing(listOf(Database("A"), Database("B"))))
                 }
             }

--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlScalarTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlScalarTest.kt
@@ -20,11 +20,10 @@ package com.charleskorn.kaml
 
 import io.kotest.assertions.asClue
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 
-class YamlScalarTest : DescribeSpec({
-    describe("a YAML scalar") {
+class YamlScalarTest : FlatFunSpec({
+    context("a YAML scalar") {
         mapOf(
             "0" to 0,
             "1" to 1,
@@ -40,7 +39,7 @@ class YamlScalarTest : DescribeSpec({
                 context("retrieving the value as an integer") {
                     val result = scalar.toInt()
 
-                    it("converts it to the expected integer") {
+                    test("converts it to the expected integer") {
                         result shouldBe expectedValue
                     }
                 }
@@ -48,7 +47,7 @@ class YamlScalarTest : DescribeSpec({
                 context("retrieving the value as a long") {
                     val result = scalar.toLong()
 
-                    it("converts it to the expected long") {
+                    test("converts it to the expected long") {
                         result shouldBe expectedValue.toLong()
                     }
                 }
@@ -56,7 +55,7 @@ class YamlScalarTest : DescribeSpec({
                 context("retrieving the value as a short") {
                     val result = scalar.toShort()
 
-                    it("converts it to the expected short") {
+                    test("converts it to the expected short") {
                         result shouldBe expectedValue.toShort()
                     }
                 }
@@ -64,7 +63,7 @@ class YamlScalarTest : DescribeSpec({
                 context("retrieving the value as a byte") {
                     val result = scalar.toByte()
 
-                    it("converts it to the expected byte") {
+                    test("converts it to the expected byte") {
                         result shouldBe expectedValue.toByte()
                     }
                 }
@@ -88,7 +87,7 @@ class YamlScalarTest : DescribeSpec({
                     val scalar = YamlScalar(content, path)
 
                     context("retrieving the value as an integer") {
-                        it("throws an appropriate exception") {
+                        test("throws an appropriate exception") {
                             val exception = shouldThrow<YamlScalarFormatException> { scalar.toInt() }
 
                             exception.asClue {
@@ -102,7 +101,7 @@ class YamlScalarTest : DescribeSpec({
                     }
 
                     context("retrieving the value as a long") {
-                        it("throws an appropriate exception") {
+                        test("throws an appropriate exception") {
                             val exception = shouldThrow<YamlScalarFormatException> { scalar.toLong() }
 
                             exception.asClue {
@@ -116,7 +115,7 @@ class YamlScalarTest : DescribeSpec({
                     }
 
                     context("retrieving the value as a short") {
-                        it("throws an appropriate exception") {
+                        test("throws an appropriate exception") {
                             val exception = shouldThrow<YamlScalarFormatException> { scalar.toShort() }
 
                             exception.asClue {
@@ -130,7 +129,7 @@ class YamlScalarTest : DescribeSpec({
                     }
 
                     context("retrieving the value as a byte") {
-                        it("throws an appropriate exception") {
+                        test("throws an appropriate exception") {
                             val exception = shouldThrow<YamlScalarFormatException> { scalar.toByte() }
 
                             exception.asClue {
@@ -174,7 +173,7 @@ class YamlScalarTest : DescribeSpec({
                     context("retrieving the value as a double") {
                         val result = scalar.toDouble()
 
-                        it("converts it to the expected double") {
+                        test("converts it to the expected double") {
                             result shouldBe expectedResult
                         }
                     }
@@ -210,7 +209,7 @@ class YamlScalarTest : DescribeSpec({
                     context("retrieving the value as a float") {
                         val result = scalar.toFloat()
 
-                        it("converts it to the expected float") {
+                        test("converts it to the expected float") {
                             result shouldBe expectedResult
                         }
                     }
@@ -234,7 +233,7 @@ class YamlScalarTest : DescribeSpec({
                     val scalar = YamlScalar(content, path)
 
                     context("retrieving the value as a float") {
-                        it("throws an appropriate exception") {
+                        test("throws an appropriate exception") {
                             val exception = shouldThrow<YamlScalarFormatException> { scalar.toFloat() }
 
                             exception.asClue {
@@ -248,7 +247,7 @@ class YamlScalarTest : DescribeSpec({
                     }
 
                     context("retrieving the value as a double") {
-                        it("throws an appropriate exception") {
+                        test("throws an appropriate exception") {
                             val exception = shouldThrow<YamlScalarFormatException> { scalar.toDouble() }
 
                             exception.asClue {
@@ -278,7 +277,7 @@ class YamlScalarTest : DescribeSpec({
                 context("retrieving the value as a boolean") {
                     val result = scalar.toBoolean()
 
-                    it("converts it to the expected value") {
+                    test("converts it to the expected value") {
                         result shouldBe expectedValue
                     }
                 }
@@ -290,7 +289,7 @@ class YamlScalarTest : DescribeSpec({
             val scalar = YamlScalar("nonsense", path)
 
             context("retrieving the value as a boolean") {
-                it("throws an appropriate exception") {
+                test("throws an appropriate exception") {
                     val exception = shouldThrow<YamlScalarFormatException> { scalar.toBoolean() }
 
                     exception.asClue {
@@ -310,7 +309,7 @@ class YamlScalarTest : DescribeSpec({
             context("retrieving the value as a character value") {
                 val result = scalar.toChar()
 
-                it("converts it to the expected value") {
+                test("converts it to the expected value") {
                     result shouldBe 'b'
                 }
             }
@@ -325,7 +324,7 @@ class YamlScalarTest : DescribeSpec({
                 val scalar = YamlScalar(content, path)
 
                 context("retrieving the value as a character value") {
-                    it("throws an appropriate exception") {
+                    test("throws an appropriate exception") {
                         val exception = shouldThrow<YamlScalarFormatException> { scalar.toChar() }
 
                         exception.asClue {
@@ -340,18 +339,18 @@ class YamlScalarTest : DescribeSpec({
             }
         }
 
-        describe("testing equivalence") {
+        context("testing equivalence") {
             val path = YamlPath.root.withListEntry(1, Location(2, 3))
             val scalar = YamlScalar("some content", path)
 
             context("comparing it to the same instance") {
-                it("indicates that they are equivalent") {
+                test("indicates that they are equivalent") {
                     scalar.equivalentContentTo(scalar) shouldBe true
                 }
             }
 
             context("comparing it to another scalar with the same content and path") {
-                it("indicates that they are equivalent") {
+                test("indicates that they are equivalent") {
                     scalar.equivalentContentTo(YamlScalar("some content", path)) shouldBe true
                 }
             }
@@ -359,56 +358,56 @@ class YamlScalarTest : DescribeSpec({
             context("comparing it to another scalar with the same content but a different path") {
                 val otherPath = YamlPath.root.withListEntry(1, Location(2, 4))
 
-                it("indicates that they are equivalent") {
+                test("indicates that they are equivalent") {
                     scalar.equivalentContentTo(YamlScalar("some content", otherPath)) shouldBe true
                 }
             }
 
             context("comparing it to another scalar with the same path but different content") {
-                it("indicates that they are not equivalent") {
+                test("indicates that they are not equivalent") {
                     scalar.equivalentContentTo(YamlScalar("some other content", path)) shouldBe false
                 }
             }
 
             context("comparing it to a null value") {
-                it("indicates that they are not equivalent") {
+                test("indicates that they are not equivalent") {
                     scalar.equivalentContentTo(YamlNull(path)) shouldBe false
                 }
             }
 
             context("comparing it to a list") {
-                it("indicates that they are not equivalent") {
+                test("indicates that they are not equivalent") {
                     scalar.equivalentContentTo(YamlList(emptyList(), path)) shouldBe false
                 }
             }
 
             context("comparing it to a map") {
-                it("indicates that they are not equivalent") {
+                test("indicates that they are not equivalent") {
                     scalar.equivalentContentTo(YamlMap(emptyMap(), path)) shouldBe false
                 }
             }
         }
 
-        describe("converting the content to a human-readable string") {
-            it("returns the content surrounded by single quotes") {
+        context("converting the content to a human-readable string") {
+            test("returns the content surrounded by single quotes") {
                 YamlScalar("thing", YamlPath.root).contentToString() shouldBe "'thing'"
             }
         }
 
-        describe("replacing its path") {
+        context("replacing its path") {
             val original = YamlScalar("abc123", YamlPath.root)
             val newPath = YamlPath.forAliasDefinition("blah", Location(2, 3))
 
-            it("returns a scalar value with the provided path") {
+            test("returns a scalar value with the provided path") {
                 original.withPath(newPath) shouldBe YamlScalar("abc123", newPath)
             }
         }
 
-        describe("converting it to a string") {
+        context("converting it to a string") {
             val path = YamlPath.root.withListEntry(2, Location(3, 4))
             val value = YamlScalar("hello world", path)
 
-            it("returns a human-readable description of itself") {
+            test("returns a human-readable description of itself") {
                 value.toString() shouldBe "scalar @ $path : hello world"
             }
         }

--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlWritingTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlWritingTest.kt
@@ -30,7 +30,6 @@ import com.charleskorn.kaml.testobjects.UnwrappedInterface
 import com.charleskorn.kaml.testobjects.UnwrappedString
 import com.charleskorn.kaml.testobjects.polymorphicModule
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.PolymorphicSerializer
 import kotlinx.serialization.Serializable
@@ -39,27 +38,27 @@ import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.nullable
 import kotlinx.serialization.builtins.serializer
 
-class YamlWritingTest : DescribeSpec({
-    describe("a YAML serializer") {
+class YamlWritingTest : FlatFunSpec({
+    context("a YAML serializer") {
         val yamlWithCustomisedIndentation = Yaml(configuration = YamlConfiguration(encodingIndentationSize = 3))
 
-        describe("serializing null values") {
+        context("serializing null values") {
             val input = null as String?
 
             context("serializing a null string value") {
                 val output = Yaml.default.encodeToString(String.serializer().nullable, input)
 
-                it("returns the value serialized in the expected YAML form") {
+                test("returns the value serialized in the expected YAML form") {
                     output shouldBe "null"
                 }
             }
         }
 
-        describe("serializing boolean values") {
+        context("serializing boolean values") {
             context("serializing a true value") {
                 val output = Yaml.default.encodeToString(Boolean.serializer(), true)
 
-                it("returns the value serialized in the expected YAML form") {
+                test("returns the value serialized in the expected YAML form") {
                     output shouldBe "true"
                 }
             }
@@ -67,25 +66,25 @@ class YamlWritingTest : DescribeSpec({
             context("serializing a false value") {
                 val output = Yaml.default.encodeToString(Boolean.serializer(), false)
 
-                it("returns the value serialized in the expected YAML form") {
+                test("returns the value serialized in the expected YAML form") {
                     output shouldBe "false"
                 }
             }
         }
 
-        describe("serializing byte values") {
+        context("serializing byte values") {
             val output = Yaml.default.encodeToString(Byte.serializer(), 12)
 
-            it("returns the value serialized in the expected YAML form") {
+            test("returns the value serialized in the expected YAML form") {
                 output shouldBe "12"
             }
         }
 
-        describe("serializing character values") {
+        context("serializing character values") {
             context("serializing a alphanumeric character") {
                 val output = Yaml.default.encodeToString(Char.serializer(), 'A')
 
-                it("returns the value serialized in the expected YAML form") {
+                test("returns the value serialized in the expected YAML form") {
                     output shouldBe """"A""""
                 }
             }
@@ -93,7 +92,7 @@ class YamlWritingTest : DescribeSpec({
             context("serializing a double-quote character") {
                 val output = Yaml.default.encodeToString(Char.serializer(), '"')
 
-                it("returns the value serialized in the expected YAML form, escaping the double-quote character") {
+                test("returns the value serialized in the expected YAML form, escaping the double-quote character") {
                     output shouldBe """"\"""""
                 }
             }
@@ -101,24 +100,24 @@ class YamlWritingTest : DescribeSpec({
             context("serializing a newline character") {
                 val output = Yaml.default.encodeToString(Char.serializer(), '\n')
 
-                it("returns the value serialized in the expected YAML form, escaping the newline character") {
+                test("returns the value serialized in the expected YAML form, escaping the newline character") {
                     output shouldBe """"\n""""
                 }
             }
         }
 
-        describe("serializing double values") {
+        context("serializing double values") {
             val output = Yaml.default.encodeToString(Double.serializer(), 12.3)
 
-            it("returns the value serialized in the expected YAML form") {
+            test("returns the value serialized in the expected YAML form") {
                 output shouldBe "12.3"
             }
         }
 
-        describe("serializing floating point values") {
+        context("serializing floating point values") {
             val output = Yaml.default.encodeToString(Float.serializer(), 45.6f)
 
-            it("returns the value serialized in the expected YAML form") {
+            test("returns the value serialized in the expected YAML form") {
                 output shouldBe when (kotlinTarget) {
                     // See a bug in Kotlin/Wasm:
                     // https://youtrack.jetbrains.com/issue/KT-68948/
@@ -128,35 +127,35 @@ class YamlWritingTest : DescribeSpec({
             }
         }
 
-        describe("serializing integer values") {
+        context("serializing integer values") {
             val output = Yaml.default.encodeToString(Int.serializer(), 12)
 
-            it("returns the value serialized in the expected YAML form") {
+            test("returns the value serialized in the expected YAML form") {
                 output shouldBe "12"
             }
         }
 
-        describe("serializing long integer values") {
+        context("serializing long integer values") {
             val output = Yaml.default.encodeToString(Long.serializer(), 12)
 
-            it("returns the value serialized in the expected YAML form") {
+            test("returns the value serialized in the expected YAML form") {
                 output shouldBe "12"
             }
         }
 
-        describe("serializing short integer values") {
+        context("serializing short integer values") {
             val output = Yaml.default.encodeToString(Short.serializer(), 12)
 
-            it("returns the value serialized in the expected YAML form") {
+            test("returns the value serialized in the expected YAML form") {
                 output shouldBe "12"
             }
         }
 
-        describe("serializing string values") {
+        context("serializing string values") {
             context("serializing a string without any special characters") {
                 val output = Yaml.default.encodeToString(String.serializer(), "hello world")
 
-                it("returns the value serialized in the expected YAML form") {
+                test("returns the value serialized in the expected YAML form") {
                     output shouldBe """"hello world""""
                 }
             }
@@ -165,7 +164,7 @@ class YamlWritingTest : DescribeSpec({
                 val output = Yaml.default.encodeToString(String.serializer(), "")
 
                 // The '---' is necessary as explained here: https://bitbucket.org/asomov/snakeyaml-engine/issues/23/emitting-only-an-empty-string-adds-to
-                it("returns the value serialized in the expected YAML form") {
+                test("returns the value serialized in the expected YAML form") {
                     output shouldBe """--- """""
                 }
             }
@@ -173,7 +172,7 @@ class YamlWritingTest : DescribeSpec({
             context("serializing the string 'null'") {
                 val output = Yaml.default.encodeToString(String.serializer(), "null")
 
-                it("returns the value serialized in the expected YAML form") {
+                test("returns the value serialized in the expected YAML form") {
                     output shouldBe """"null""""
                 }
             }
@@ -181,7 +180,7 @@ class YamlWritingTest : DescribeSpec({
             context("serializing a multi-line string") {
                 val output = Yaml.default.encodeToString(String.serializer(), "This is line 1\nThis is line 2")
 
-                it("returns the value serialized in the expected YAML form, escaping the newline character") {
+                test("returns the value serialized in the expected YAML form, escaping the newline character") {
                     output shouldBe """"This is line 1\nThis is line 2""""
                 }
             }
@@ -189,7 +188,7 @@ class YamlWritingTest : DescribeSpec({
             context("serializing a string containing a double-quote character") {
                 val output = Yaml.default.encodeToString(String.serializer(), """They said "hello" to me""")
 
-                it("returns the value serialized in the expected YAML form, escaping the double-quote characters") {
+                test("returns the value serialized in the expected YAML form, escaping the double-quote characters") {
                     output shouldBe """"They said \"hello\" to me""""
                 }
             }
@@ -197,7 +196,7 @@ class YamlWritingTest : DescribeSpec({
             context("serializing a string longer than the maximum scalar width") {
                 val output = Yaml(configuration = YamlConfiguration(breakScalarsAt = 80)).encodeToString(String.serializer(), "Hello world this is a string that is much, much, much (ok, not that much) longer than 80 characters")
 
-                it("returns the value serialized in the expected YAML form, broken onto a new line at the maximum scalar width") {
+                test("returns the value serialized in the expected YAML form, broken onto a new line at the maximum scalar width") {
                     output shouldBe
                         """
                         |"Hello world this is a string that is much, much, much (ok, not that much) longer\
@@ -209,7 +208,7 @@ class YamlWritingTest : DescribeSpec({
             context("serializing a string with the value of an integer using SingleLineStringStyle.PlainExceptAmbiguous") {
                 val output = Yaml(configuration = YamlConfiguration(singleLineStringStyle = SingleLineStringStyle.PlainExceptAmbiguous)).encodeToString(String.serializer(), "12")
 
-                it("returns the value serialized in the expected YAML form, escaping the integer") {
+                test("returns the value serialized in the expected YAML form, escaping the integer") {
                     output shouldBe """"12""""
                 }
             }
@@ -217,7 +216,7 @@ class YamlWritingTest : DescribeSpec({
             context("serializing a string with the value of a boolean using SingleLineStringStyle.PlainExceptAmbiguous") {
                 val output = Yaml(configuration = YamlConfiguration(singleLineStringStyle = SingleLineStringStyle.PlainExceptAmbiguous)).encodeToString(String.serializer(), "true")
 
-                it("returns the value serialized in the expected YAML form, escaping the boolean") {
+                test("returns the value serialized in the expected YAML form, escaping the boolean") {
                     output shouldBe """"true""""
                 }
             }
@@ -225,7 +224,7 @@ class YamlWritingTest : DescribeSpec({
             context("serializing a string with the value of an float using SingleLineStringStyle.PlainExceptAmbiguous") {
                 val output = Yaml(configuration = YamlConfiguration(singleLineStringStyle = SingleLineStringStyle.PlainExceptAmbiguous)).encodeToString(String.serializer(), "1.2")
 
-                it("returns the value serialized in the expected YAML form, escaping the float") {
+                test("returns the value serialized in the expected YAML form, escaping the float") {
                     output shouldBe """"1.2""""
                 }
             }
@@ -233,7 +232,7 @@ class YamlWritingTest : DescribeSpec({
             context("serializing an unambiguous numerical string using SingleLineStringStyle.PlainExceptAmbiguous") {
                 val output = Yaml(configuration = YamlConfiguration(singleLineStringStyle = SingleLineStringStyle.PlainExceptAmbiguous)).encodeToString(String.serializer(), "1.2.3")
 
-                it("returns the value serialized in the expected YAML form, without being escaped") {
+                test("returns the value serialized in the expected YAML form, without being escaped") {
                     output shouldBe "1.2.3"
                 }
             }
@@ -241,7 +240,7 @@ class YamlWritingTest : DescribeSpec({
             context("serializing an int using SingleLineStringStyle.PlainExceptAmbiguous") {
                 val output = Yaml(configuration = YamlConfiguration(singleLineStringStyle = SingleLineStringStyle.PlainExceptAmbiguous)).encodeToString(Int.serializer(), 123)
 
-                it("returns the value serialized in the expected YAML form, without being escaped") {
+                test("returns the value serialized in the expected YAML form, without being escaped") {
                     output shouldBe "123"
                 }
             }
@@ -249,7 +248,7 @@ class YamlWritingTest : DescribeSpec({
             context("serializing a float using SingleLineStringStyle.PlainExceptAmbiguous") {
                 val output = Yaml(configuration = YamlConfiguration(singleLineStringStyle = SingleLineStringStyle.PlainExceptAmbiguous)).encodeToString(Float.serializer(), 1.2f)
 
-                it("returns the value serialized in the expected YAML form, without being escaped") {
+                test("returns the value serialized in the expected YAML form, without being escaped") {
                     output shouldBe when (kotlinTarget) {
                         // See a bug in Kotlin/Wasm:
                         // https://youtrack.jetbrains.com/issue/KT-68948/
@@ -262,7 +261,7 @@ class YamlWritingTest : DescribeSpec({
             context("serializing a boolean using SingleLineStringStyle.PlainExceptAmbiguous") {
                 val output = Yaml(configuration = YamlConfiguration(singleLineStringStyle = SingleLineStringStyle.PlainExceptAmbiguous)).encodeToString(Boolean.serializer(), true)
 
-                it("returns the value serialized in the expected YAML form, without being escaped") {
+                test("returns the value serialized in the expected YAML form, without being escaped") {
                     output shouldBe "true"
                 }
             }
@@ -275,7 +274,7 @@ class YamlWritingTest : DescribeSpec({
                     ),
                 ).encodeToString(String.serializer(), "12")
 
-                it("returns the value serialized in the expected YAML form, escaping the integer with single-quotes") {
+                test("returns the value serialized in the expected YAML form, escaping the integer with single-quotes") {
                     output shouldBe """'12'"""
                 }
             }
@@ -288,7 +287,7 @@ class YamlWritingTest : DescribeSpec({
                     ),
                 ).encodeToString(String.serializer(), "true")
 
-                it("returns the value serialized in the expected YAML form, escaping the boolean with single-quotes") {
+                test("returns the value serialized in the expected YAML form, escaping the boolean with single-quotes") {
                     output shouldBe """'true'"""
                 }
             }
@@ -301,7 +300,7 @@ class YamlWritingTest : DescribeSpec({
                     ),
                 ).encodeToString(String.serializer(), "1.2")
 
-                it("returns the value serialized in the expected YAML form, escaping the float with single-quotes") {
+                test("returns the value serialized in the expected YAML form, escaping the float with single-quotes") {
                     output shouldBe """'1.2'"""
                 }
             }
@@ -316,7 +315,7 @@ class YamlWritingTest : DescribeSpec({
                     configuration = YamlConfiguration(yamlNamingStrategy = YamlNamingStrategy.SnakeCase),
                 ).encodeToString(NamingStrategyTestData.serializer(), NamingStrategyTestData("value"))
 
-                it("returns the serial name serialized in snake_case") {
+                test("returns the serial name serialized in snake_case") {
                     output shouldBe """serial_name: "value""""
                 }
             }
@@ -326,7 +325,7 @@ class YamlWritingTest : DescribeSpec({
                     configuration = YamlConfiguration(yamlNamingStrategy = YamlNamingStrategy.PascalCase),
                 ).encodeToString(NamingStrategyTestData.serializer(), NamingStrategyTestData("value"))
 
-                it("returns the serial name serialized in PascalCase") {
+                test("returns the serial name serialized in PascalCase") {
                     output shouldBe """SerialName: "value""""
                 }
             }
@@ -336,7 +335,7 @@ class YamlWritingTest : DescribeSpec({
                     configuration = YamlConfiguration(yamlNamingStrategy = YamlNamingStrategy.CamelCase),
                 ).encodeToString(NamingStrategyTestData.serializer(), NamingStrategyTestData("value"))
 
-                it("returns the serial name serialized in camelCase") {
+                test("returns the serial name serialized in camelCase") {
                     output shouldBe """serialName: "value""""
                 }
             }
@@ -346,7 +345,7 @@ class YamlWritingTest : DescribeSpec({
                     configuration = YamlConfiguration(yamlNamingStrategy = YamlNamingStrategy.KebabCase),
                 ).encodeToString(NamingStrategyTestData.serializer(), NamingStrategyTestData("value"))
 
-                it("returns the serial name serialized in camelCase") {
+                test("returns the serial name serialized in camelCase") {
                     output shouldBe """serial-name: "value""""
                 }
             }
@@ -356,7 +355,7 @@ class YamlWritingTest : DescribeSpec({
                     configuration = YamlConfiguration(yamlNamingStrategy = YamlNamingStrategy.PascalCase),
                 ).encodeToString(NamingStrategyTestData.serializer(), NamingStrategyTestData("value_with_several_words"))
 
-                it("returns only the name serialized in PascalCase and not the value too") {
+                test("returns only the name serialized in PascalCase and not the value too") {
                     output shouldBe """SerialName: "value_with_several_words""""
                 }
             }
@@ -368,7 +367,7 @@ class YamlWritingTest : DescribeSpec({
                     configuration = YamlConfiguration(yamlNamingStrategy = YamlNamingStrategy.SnakeCase),
                 ).encodeToString(LongSerialName.serializer(), LongSerialName("value"))
 
-                it("returns the name serialized correctly") {
+                test("returns the name serialized correctly") {
                     output shouldBe """really_long_serial_name: "value""""
                 }
             }
@@ -380,7 +379,7 @@ class YamlWritingTest : DescribeSpec({
                     configuration = YamlConfiguration(yamlNamingStrategy = YamlNamingStrategy.PascalCase),
                 ).encodeToString(OneCharacterSerialName.serializer(), OneCharacterSerialName("value"))
 
-                it("returns the name serialized correctly") {
+                test("returns the name serialized correctly") {
                     output shouldBe """A: "value""""
                 }
             }
@@ -392,25 +391,25 @@ class YamlWritingTest : DescribeSpec({
                     configuration = YamlConfiguration(yamlNamingStrategy = YamlNamingStrategy.PascalCase),
                 ).encodeToString(OneWordSerialName.serializer(), OneWordSerialName("value"))
 
-                it("returns the name serialized correctly") {
+                test("returns the name serialized correctly") {
                     output shouldBe """Name: "value""""
                 }
             }
         }
 
-        describe("serializing enumeration values") {
+        context("serializing enumeration values") {
             val output = Yaml.default.encodeToString(TestEnum.serializer(), TestEnum.Value1)
 
-            it("returns the value serialized in the expected YAML form") {
+            test("returns the value serialized in the expected YAML form") {
                 output shouldBe """"Value1""""
             }
         }
 
-        describe("serializing lists") {
+        context("serializing lists") {
             context("serializing a list of integers") {
                 val output = Yaml.default.encodeToString(ListSerializer(Int.serializer()), listOf(1, 2, 3))
 
-                it("returns the value serialized in the expected YAML form") {
+                test("returns the value serialized in the expected YAML form") {
                     output shouldBe
                         """
                             - 1
@@ -423,7 +422,7 @@ class YamlWritingTest : DescribeSpec({
                 val output = Yaml(configuration = YamlConfiguration(sequenceStyle = SequenceStyle.Flow))
                     .encodeToString(ListSerializer(Int.serializer()), listOf(1, 2, 3))
 
-                it("returns the value serialized in the expected YAML form") {
+                test("returns the value serialized in the expected YAML form") {
                     output shouldBe "[1, 2, 3]"
                 }
             }
@@ -431,7 +430,7 @@ class YamlWritingTest : DescribeSpec({
             context("serializing a list of nullable integers") {
                 val output = Yaml.default.encodeToString(ListSerializer(Int.serializer().nullable), listOf(1, null, 3))
 
-                it("returns the value serialized in the expected YAML form") {
+                test("returns the value serialized in the expected YAML form") {
                     output shouldBe
                         """
                             - 1
@@ -445,7 +444,7 @@ class YamlWritingTest : DescribeSpec({
                 val output = Yaml(configuration = YamlConfiguration(sequenceStyle = SequenceStyle.Flow, sequenceBlockIndent = 2))
                     .encodeToString(ListSerializer(Int.serializer()), listOf(1, 2, 3))
 
-                it("returns the value serialized in the expected YAML form") {
+                test("returns the value serialized in the expected YAML form") {
                     output shouldBe "[1, 2, 3]"
                 }
             }
@@ -454,7 +453,7 @@ class YamlWritingTest : DescribeSpec({
                 val output = Yaml(configuration = YamlConfiguration(sequenceBlockIndent = 0))
                     .encodeToString(ListSerializer(Int.serializer()), listOf(1, 2, 3))
 
-                it("returns the value serialized in the expected YAML form") {
+                test("returns the value serialized in the expected YAML form") {
                     output shouldBe
                         """
                         |- 1
@@ -468,7 +467,7 @@ class YamlWritingTest : DescribeSpec({
                 val output = Yaml(configuration = YamlConfiguration(sequenceBlockIndent = 2))
                     .encodeToString(ListSerializer(Int.serializer()), listOf(1, 2, 3))
 
-                it("returns the value serialized in the expected YAML form") {
+                test("returns the value serialized in the expected YAML form") {
                     output shouldBe
                         """
                         |  - 1
@@ -485,7 +484,7 @@ class YamlWritingTest : DescribeSpec({
                 val output = Yaml(configuration = YamlConfiguration(sequenceBlockIndent = 2))
                     .encodeToString(ListSerializer(Foo.serializer()), listOf(Foo("baz")))
 
-                it("returns the value serialized in the expected YAML form") {
+                test("returns the value serialized in the expected YAML form") {
                     output shouldBe
                         """
                         |  - bar: "baz"
@@ -497,7 +496,7 @@ class YamlWritingTest : DescribeSpec({
                 val output = Yaml(configuration = YamlConfiguration(sequenceStyle = SequenceStyle.Flow))
                     .encodeToString(ListSerializer(Int.serializer().nullable), listOf(1, null, 3))
 
-                it("returns the value serialized in the expected YAML form") {
+                test("returns the value serialized in the expected YAML form") {
                     output shouldBe "[1, null, 3]"
                 }
             }
@@ -505,7 +504,7 @@ class YamlWritingTest : DescribeSpec({
             context("serializing a list of strings") {
                 val output = Yaml.default.encodeToString(ListSerializer(String.serializer()), listOf("item1", "item2"))
 
-                it("returns the value serialized in the expected YAML form") {
+                test("returns the value serialized in the expected YAML form") {
                     output shouldBe
                         """
                             - "item1"
@@ -518,7 +517,7 @@ class YamlWritingTest : DescribeSpec({
                 val output = Yaml(configuration = YamlConfiguration(sequenceStyle = SequenceStyle.Flow))
                     .encodeToString(ListSerializer(String.serializer()), listOf("item1", "item2"))
 
-                it("returns the value serialized in the expected YAML form") {
+                test("returns the value serialized in the expected YAML form") {
                     output shouldBe """["item1", "item2"]"""
                 }
             }
@@ -527,7 +526,7 @@ class YamlWritingTest : DescribeSpec({
                 val yamlWithScalarLimit = Yaml(configuration = YamlConfiguration(breakScalarsAt = 80))
                 val output = yamlWithScalarLimit.encodeToString(ListSerializer(String.serializer()), listOf("item1", "Hello world this is a string that is much, much, much (ok, not that much) longer than 80 characters"))
 
-                it("returns the value serialized in the expected YAML form, broken onto a new line at the maximum scalar width") {
+                test("returns the value serialized in the expected YAML form, broken onto a new line at the maximum scalar width") {
                     output shouldBe
                         """
                         |- "item1"
@@ -541,7 +540,7 @@ class YamlWritingTest : DescribeSpec({
                 val yamlWithScalarLimit = Yaml(configuration = YamlConfiguration(breakScalarsAt = 80, sequenceStyle = SequenceStyle.Flow))
                 val output = yamlWithScalarLimit.encodeToString(ListSerializer(String.serializer()), listOf("item1", "Hello world this is a string that is much, much, much (ok, not that much) longer than 80 characters"))
 
-                it("returns the value serialized in the expected YAML form, broken onto a new line at the maximum scalar width") {
+                test("returns the value serialized in the expected YAML form, broken onto a new line at the maximum scalar width") {
                     output shouldBe
                         """
                             ["item1", "Hello world this is a string that is much, much, much (ok, not that much)\
@@ -558,7 +557,7 @@ class YamlWritingTest : DescribeSpec({
 
                 val output = Yaml.default.encodeToString(ListSerializer(ListSerializer(Int.serializer())), input)
 
-                it("returns the value serialized in the expected YAML form") {
+                test("returns the value serialized in the expected YAML form") {
                     output shouldBe
                         """
                             - - 1
@@ -579,7 +578,7 @@ class YamlWritingTest : DescribeSpec({
                 val output = Yaml(configuration = YamlConfiguration(sequenceStyle = SequenceStyle.Flow))
                     .encodeToString(ListSerializer(ListSerializer(Int.serializer())), input)
 
-                it("returns the value serialized in the expected YAML form") {
+                test("returns the value serialized in the expected YAML form") {
                     output shouldBe """[[1, 2, 3], [4, 5]]"""
                 }
             }
@@ -598,7 +597,7 @@ class YamlWritingTest : DescribeSpec({
                 val serializer = ListSerializer(MapSerializer(String.serializer(), String.serializer()))
                 val output = Yaml.default.encodeToString(serializer, input)
 
-                it("returns the value serialized in the expected YAML form") {
+                test("returns the value serialized in the expected YAML form") {
                     output shouldBe
                         """
                             - "key1": "value1"
@@ -616,7 +615,7 @@ class YamlWritingTest : DescribeSpec({
 
                 val output = Yaml.default.encodeToString(ListSerializer(SimpleStructure.serializer()), input)
 
-                it("returns the value serialized in the expected YAML form") {
+                test("returns the value serialized in the expected YAML form") {
                     output shouldBe
                         """
                             - name: "name1"
@@ -632,7 +631,7 @@ class YamlWritingTest : DescribeSpec({
 
                 val output = Yaml(configuration = YamlConfiguration(sequenceStyle = SequenceStyle.Flow)).encodeToString(ListSerializer(SimpleStructure.serializer()), input)
 
-                it("returns the value serialized in the expected YAML form") {
+                test("returns the value serialized in the expected YAML form") {
                     output shouldBe
                         """
                             [{name: "name1"}, {name: "name2"}]
@@ -641,7 +640,7 @@ class YamlWritingTest : DescribeSpec({
             }
         }
 
-        describe("serializing maps") {
+        context("serializing maps") {
             context("serializing a map of strings to strings") {
                 val input = mapOf(
                     "key1" to "value1",
@@ -650,7 +649,7 @@ class YamlWritingTest : DescribeSpec({
 
                 val output = Yaml.default.encodeToString(MapSerializer(String.serializer(), String.serializer()), input)
 
-                it("returns the value serialized in the expected YAML form") {
+                test("returns the value serialized in the expected YAML form") {
                     output shouldBe
                         """
                             "key1": "value1"
@@ -673,7 +672,7 @@ class YamlWritingTest : DescribeSpec({
                 val serializer = MapSerializer(String.serializer(), MapSerializer(String.serializer(), String.serializer()))
                 val output = Yaml.default.encodeToString(serializer, input)
 
-                it("returns the value serialized in the expected YAML form") {
+                test("returns the value serialized in the expected YAML form") {
                     output shouldBe
                         """
                             "map1":
@@ -694,7 +693,7 @@ class YamlWritingTest : DescribeSpec({
                 val serializer = MapSerializer(String.serializer(), ListSerializer(Int.serializer()))
                 val output = Yaml.default.encodeToString(serializer, input)
 
-                it("returns the value serialized in the expected YAML form") {
+                test("returns the value serialized in the expected YAML form") {
                     output shouldBe
                         """
                             "list1":
@@ -718,7 +717,7 @@ class YamlWritingTest : DescribeSpec({
                 val serializer = MapSerializer(String.serializer(), SimpleStructure.serializer())
                 val output = Yaml.default.encodeToString(serializer, input)
 
-                it("returns the value serialized in the expected YAML form") {
+                test("returns the value serialized in the expected YAML form") {
                     output shouldBe
                         """
                             "item1":
@@ -730,12 +729,12 @@ class YamlWritingTest : DescribeSpec({
             }
         }
 
-        describe("serializing objects") {
+        context("serializing objects") {
             context("serializing a simple object") {
                 val input = SimpleStructure("The name")
                 val output = Yaml.default.encodeToString(SimpleStructure.serializer(), input)
 
-                it("returns the value serialized in the expected YAML form") {
+                test("returns the value serialized in the expected YAML form") {
                     output shouldBe
                         """
                             name: "The name"
@@ -752,7 +751,7 @@ class YamlWritingTest : DescribeSpec({
                 context("with default indentation") {
                     val output = Yaml.default.encodeToString(NestedObjects.serializer(), input)
 
-                    it("returns the value serialized in the expected YAML form") {
+                    test("returns the value serialized in the expected YAML form") {
                         output shouldBe
                             """
                                 firstPerson:
@@ -766,7 +765,7 @@ class YamlWritingTest : DescribeSpec({
                 context("with customised indentation") {
                     val output = yamlWithCustomisedIndentation.encodeToString(NestedObjects.serializer(), input)
 
-                    it("returns the value serialized in the expected YAML form") {
+                    test("returns the value serialized in the expected YAML form") {
                         output shouldBe
                             """
                                 firstPerson:
@@ -784,7 +783,7 @@ class YamlWritingTest : DescribeSpec({
                 context("with default indentation") {
                     val output = Yaml.default.encodeToString(Team.serializer(), input)
 
-                    it("returns the value serialized in the expected YAML form") {
+                    test("returns the value serialized in the expected YAML form") {
                         output shouldBe
                             """
                                 members:
@@ -797,7 +796,7 @@ class YamlWritingTest : DescribeSpec({
                 context("with customised indentation") {
                     val output = yamlWithCustomisedIndentation.encodeToString(Team.serializer(), input)
 
-                    it("returns the value serialized in the expected YAML form") {
+                    test("returns the value serialized in the expected YAML form") {
                         output shouldBe
                             """
                                 members:
@@ -818,7 +817,7 @@ class YamlWritingTest : DescribeSpec({
 
                 val output = Yaml.default.encodeToString(ThingWithMap.serializer(), input)
 
-                it("returns the value serialized in the expected YAML form") {
+                test("returns the value serialized in the expected YAML form") {
                     output shouldBe
                         """
                             variables:
@@ -829,11 +828,11 @@ class YamlWritingTest : DescribeSpec({
             }
         }
 
-        describe("serializing polymorphic values") {
-            describe("given tags are used to store the type information") {
+        context("serializing polymorphic values") {
+            context("given tags are used to store the type information") {
                 val polymorphicYaml = Yaml(serializersModule = polymorphicModule, configuration = YamlConfiguration(polymorphismStyle = PolymorphismStyle.Tag))
 
-                describe("serializing a sealed type") {
+                context("serializing a sealed type") {
                     val input = TestSealedStructure.SimpleSealedInt(5)
                     val output = polymorphicYaml.encodeToString(TestSealedStructure.serializer(), input)
                     val expectedYaml = """
@@ -841,12 +840,12 @@ class YamlWritingTest : DescribeSpec({
                         value: 5
                     """.trimIndent()
 
-                    it("returns the value serialized in the expected YAML form") {
+                    test("returns the value serialized in the expected YAML form") {
                         output shouldBe expectedYaml
                     }
                 }
 
-                describe("serializing an unsealed type") {
+                context("serializing an unsealed type") {
                     val input = UnsealedString("blah")
                     val output = polymorphicYaml.encodeToString(PolymorphicSerializer(UnsealedClass::class), input)
                     val expectedYaml = """
@@ -854,24 +853,24 @@ class YamlWritingTest : DescribeSpec({
                         value: "blah"
                     """.trimIndent()
 
-                    it("returns the value serialized in the expected YAML form") {
+                    test("returns the value serialized in the expected YAML form") {
                         output shouldBe expectedYaml
                     }
                 }
 
-                describe("serializing an unwrapped type") {
+                context("serializing an unwrapped type") {
                     val input = UnwrappedString("blah")
                     val output = polymorphicYaml.encodeToString(PolymorphicSerializer(UnwrappedInterface::class), input)
                     val expectedYaml = """
                         !<simpleString> "blah"
                     """.trimIndent()
 
-                    it("returns the value serialized in the expected YAML form") {
+                    test("returns the value serialized in the expected YAML form") {
                         output shouldBe expectedYaml
                     }
                 }
 
-                describe("serializing a polymorphic value as a property value") {
+                context("serializing a polymorphic value as a property value") {
                     val input = SealedWrapper(TestSealedStructure.SimpleSealedInt(5))
                     val output = polymorphicYaml.encodeToString(SealedWrapper.serializer(), input)
                     val expectedYaml = """
@@ -879,12 +878,12 @@ class YamlWritingTest : DescribeSpec({
                           value: 5
                     """.trimIndent()
 
-                    it("returns the value serialized in the expected YAML form") {
+                    test("returns the value serialized in the expected YAML form") {
                         output shouldBe expectedYaml
                     }
                 }
 
-                describe("serializing a list of polymorphic values") {
+                context("serializing a list of polymorphic values") {
                     val input = listOf(
                         TestSealedStructure.SimpleSealedInt(5),
                         TestSealedStructure.SimpleSealedString("some test"),
@@ -907,16 +906,16 @@ class YamlWritingTest : DescribeSpec({
                         - null
                     """.trimIndent()
 
-                    it("returns the value serialized in the expected YAML form") {
+                    test("returns the value serialized in the expected YAML form") {
                         output shouldBe expectedYaml
                     }
                 }
             }
 
-            describe("given properties are used to store the type information") {
+            context("given properties are used to store the type information") {
                 val polymorphicYaml = Yaml(serializersModule = polymorphicModule, configuration = YamlConfiguration(polymorphismStyle = PolymorphismStyle.Property))
 
-                describe("serializing a sealed type") {
+                context("serializing a sealed type") {
                     val input = TestSealedStructure.SimpleSealedInt(5)
                     val output = polymorphicYaml.encodeToString(TestSealedStructure.serializer(), input)
                     val expectedYaml = """
@@ -924,12 +923,12 @@ class YamlWritingTest : DescribeSpec({
                         value: 5
                     """.trimIndent()
 
-                    it("returns the value serialized in the expected YAML form") {
+                    test("returns the value serialized in the expected YAML form") {
                         output shouldBe expectedYaml
                     }
                 }
 
-                describe("serializing an unsealed type") {
+                context("serializing an unsealed type") {
                     val input = UnsealedString("blah")
                     val output = polymorphicYaml.encodeToString(PolymorphicSerializer(UnsealedClass::class), input)
                     val expectedYaml = """
@@ -937,21 +936,21 @@ class YamlWritingTest : DescribeSpec({
                         value: "blah"
                     """.trimIndent()
 
-                    it("returns the value serialized in the expected YAML form") {
+                    test("returns the value serialized in the expected YAML form") {
                         output shouldBe expectedYaml
                     }
                 }
 
-                describe("serializing an unwrapped type") {
+                context("serializing an unwrapped type") {
                     val input = UnwrappedString("blah")
 
-                    it("throws an appropriate exception") {
+                    test("throws an appropriate exception") {
                         val exception = shouldThrow<IllegalStateException> { polymorphicYaml.encodeToString(PolymorphicSerializer(UnwrappedInterface::class), input) }
                         exception.message shouldBe "Cannot serialize a polymorphic value that is not a YAML object when using PolymorphismStyle.Property."
                     }
                 }
 
-                describe("serializing a polymorphic value as a property value") {
+                context("serializing a polymorphic value as a property value") {
                     val input = SealedWrapper(TestSealedStructure.SimpleSealedInt(5))
                     val output = polymorphicYaml.encodeToString(SealedWrapper.serializer(), input)
                     val expectedYaml = """
@@ -960,12 +959,12 @@ class YamlWritingTest : DescribeSpec({
                           value: 5
                     """.trimIndent()
 
-                    it("returns the value serialized in the expected YAML form") {
+                    test("returns the value serialized in the expected YAML form") {
                         output shouldBe expectedYaml
                     }
                 }
 
-                describe("serializing a list of polymorphic values") {
+                context("serializing a list of polymorphic values") {
                     val input = listOf(
                         TestSealedStructure.SimpleSealedInt(5),
                         TestSealedStructure.SimpleSealedString("some test"),
@@ -988,16 +987,16 @@ class YamlWritingTest : DescribeSpec({
                         - null
                     """.trimIndent()
 
-                    it("returns the value serialized in the expected YAML form") {
+                    test("returns the value serialized in the expected YAML form") {
                         output shouldBe expectedYaml
                     }
                 }
             }
 
-            describe("given custom property name are used to store the type information") {
+            context("given custom property name are used to store the type information") {
                 val polymorphicYaml = Yaml(serializersModule = polymorphicModule, configuration = YamlConfiguration(polymorphismStyle = PolymorphismStyle.Property, polymorphismPropertyName = "kind"))
 
-                describe("serializing a sealed type") {
+                context("serializing a sealed type") {
                     val input = TestSealedStructure.SimpleSealedInt(5)
                     val output = polymorphicYaml.encodeToString(TestSealedStructure.serializer(), input)
                     val expectedYaml = """
@@ -1005,12 +1004,12 @@ class YamlWritingTest : DescribeSpec({
                         value: 5
                     """.trimIndent()
 
-                    it("returns the value serialized in the expected YAML form") {
+                    test("returns the value serialized in the expected YAML form") {
                         output shouldBe expectedYaml
                     }
                 }
 
-                describe("serializing an unsealed type") {
+                context("serializing an unsealed type") {
                     val input = UnsealedString("blah")
                     val output = polymorphicYaml.encodeToString(PolymorphicSerializer(UnsealedClass::class), input)
                     val expectedYaml = """
@@ -1018,21 +1017,21 @@ class YamlWritingTest : DescribeSpec({
                         value: "blah"
                     """.trimIndent()
 
-                    it("returns the value serialized in the expected YAML form") {
+                    test("returns the value serialized in the expected YAML form") {
                         output shouldBe expectedYaml
                     }
                 }
 
-                describe("serializing an unwrapped type") {
+                context("serializing an unwrapped type") {
                     val input = UnwrappedString("blah")
 
-                    it("throws an appropriate exception") {
+                    test("throws an appropriate exception") {
                         val exception = shouldThrow<IllegalStateException> { polymorphicYaml.encodeToString(PolymorphicSerializer(UnwrappedInterface::class), input) }
                         exception.message shouldBe "Cannot serialize a polymorphic value that is not a YAML object when using PolymorphismStyle.Property."
                     }
                 }
 
-                describe("serializing a polymorphic value as a property value") {
+                context("serializing a polymorphic value as a property value") {
                     val input = SealedWrapper(TestSealedStructure.SimpleSealedInt(5))
                     val output = polymorphicYaml.encodeToString(SealedWrapper.serializer(), input)
                     val expectedYaml = """
@@ -1041,12 +1040,12 @@ class YamlWritingTest : DescribeSpec({
                           value: 5
                     """.trimIndent()
 
-                    it("returns the value serialized in the expected YAML form") {
+                    test("returns the value serialized in the expected YAML form") {
                         output shouldBe expectedYaml
                     }
                 }
 
-                describe("serializing a list of polymorphic values") {
+                context("serializing a list of polymorphic values") {
                     val input = listOf(
                         TestSealedStructure.SimpleSealedInt(5),
                         TestSealedStructure.SimpleSealedString("some test"),
@@ -1069,21 +1068,21 @@ class YamlWritingTest : DescribeSpec({
                         - null
                     """.trimIndent()
 
-                    it("returns the value serialized in the expected YAML form") {
+                    test("returns the value serialized in the expected YAML form") {
                         output shouldBe expectedYaml
                     }
                 }
             }
         }
 
-        describe("handling default values") {
+        context("handling default values") {
             context("when encoding defaults") {
                 val defaultEncoder = Yaml.default
 
                 context("given a property with no default value") {
                     val input = SimpleStructure("name1")
 
-                    it("is always written") {
+                    test("is always written") {
                         defaultEncoder.encodeToString(SimpleStructure.serializer(), input) shouldBe """name: "name1""""
                     }
                 }
@@ -1091,7 +1090,7 @@ class YamlWritingTest : DescribeSpec({
                 context("given a property with a default value") {
                     val input = SimpleStructureWithDefault()
 
-                    it("is written") {
+                    test("is written") {
                         defaultEncoder.encodeToString(SimpleStructureWithDefault.serializer(), input) shouldBe """name: "default""""
                     }
                 }
@@ -1099,7 +1098,7 @@ class YamlWritingTest : DescribeSpec({
                 context("given a property with a default value has a non-default value") {
                     val input = SimpleStructureWithDefault("name1")
 
-                    it("is written") {
+                    test("is written") {
                         defaultEncoder.encodeToString(SimpleStructureWithDefault.serializer(), input) shouldBe """name: "name1""""
                     }
                 }
@@ -1111,7 +1110,7 @@ class YamlWritingTest : DescribeSpec({
                 context("given a property with no default value") {
                     val input = SimpleStructure("name1")
 
-                    it("is always written") {
+                    test("is always written") {
                         noDefaultEncoder.encodeToString(SimpleStructure.serializer(), input) shouldBe """name: "name1""""
                     }
                 }
@@ -1119,7 +1118,7 @@ class YamlWritingTest : DescribeSpec({
                 context("given a property with a default value") {
                     val input = SimpleStructureWithDefault()
 
-                    it("is not written") {
+                    test("is not written") {
                         noDefaultEncoder.encodeToString(SimpleStructureWithDefault.serializer(), input) shouldBe """{}"""
                     }
                 }
@@ -1127,18 +1126,18 @@ class YamlWritingTest : DescribeSpec({
                 context("given a property with a default value has a non-default value") {
                     val input = SimpleStructureWithDefault("name1")
 
-                    it("is written") {
+                    test("is written") {
                         noDefaultEncoder.encodeToString(SimpleStructureWithDefault.serializer(), input) shouldBe """name: "name1""""
                     }
                 }
             }
         }
 
-        describe("handling comments") {
+        context("handling comments") {
             context("comments in kotlin object") {
                 val input = SimpleStructureWithComments("objName", 73, "justTest")
 
-                it("is written") {
+                test("is written") {
                     Yaml.default.encodeToString(SimpleStructureWithComments.serializer(), input) shouldBe """
                         name: "objName"
                         # Cool int


### PR DESCRIPTION
Two changes were needed:
* I got help from the Kotlin team regarding running Wasm tests, it was about regenerating the Yarn lockfile by removing `build/js/yarn.lock` and then running the tests again: https://youtrack.jetbrains.com/issue/KT-68950/Wasm-test-task-fails-with-multiple-Could-not-write-XML-test-results-...#focus=Comments-27-9945807.0-0
* applied a workaround for the nested tests, suggested here: https://kotlinlang.slack.com/archives/CT0G9SD7Z/p1718706660788649?thread_ts=1718703411.234529&cid=CT0G9SD7Z

JS tests still fail, mostly with `AssertionFailedError: expected:<NaN> but was:<NaN>`, so leaving them disabled.