### PR TITLE
Correct handling of `SerialKind.CONTEXTUAL` in `YamlInput` class

### DIFF
--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlReadingTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlReadingTest.kt
@@ -2079,7 +2079,7 @@ class YamlReadingTest : FlatFunSpec({
                     override val descriptor: SerialDescriptor
                         get() = String.serializer().descriptor
 
-                    override fun deserialize(decoder: Decoder): Inner = Inner(decoder.decodeString())
+                    override fun deserialize(decoder: Decoder): Inner = Inner("from context serializer: ${decoder.decodeString()}")
                     override fun serialize(encoder: Encoder, value: Inner) = throw UnsupportedOperationException()
                 }
 
@@ -2093,7 +2093,7 @@ class YamlReadingTest : FlatFunSpec({
                 val result = parser.decodeFromString(Container.serializer(), input)
 
                 test("deserializes it using the dynamically installed serializer") {
-                    result shouldBe Container(Inner("this is the input"))
+                    result shouldBe Container(Inner("from context serializer: this is the input"))
                 }
             }
 

--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlReadingTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlReadingTest.kt
@@ -2079,7 +2079,7 @@ class YamlReadingTest : FlatFunSpec({
                     override val descriptor: SerialDescriptor
                         get() = String.serializer().descriptor
 
-                    override fun deserialize(decoder: Decoder): Inner = Inner("from context serializer")
+                    override fun deserialize(decoder: Decoder): Inner = Inner(decoder.decodeString())
                     override fun serialize(encoder: Encoder, value: Inner) = throw UnsupportedOperationException()
                 }
 
@@ -2093,7 +2093,7 @@ class YamlReadingTest : FlatFunSpec({
                 val result = parser.decodeFromString(Container.serializer(), input)
 
                 test("deserializes it using the dynamically installed serializer") {
-                    result shouldBe Container(Inner("from context serializer"))
+                    result shouldBe Container(Inner("this is the input"))
                 }
             }
 


### PR DESCRIPTION
Hi, @charleskorn.

This PR corrects how `YamlInput` handles the serialization of fields marked with `@Contextual` annotation.
Instead of forcing the serializer to call `beginStructure` it extracts the actual definition and creates the appropriate `YamlInput` based on that definition where applicable.

Please, take a look at the PR once you have time. Let me know if you have any remarks/suggestions regarding the change

Resolves #568 