### PR TITLE
Update tests to run for JS targets

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,18 +46,8 @@ kotlin {
     }
 
     js(IR) {
-        browser {
-            testTask {
-                // TODO: enable once the tests work with Kotlin/JS.
-                enabled = false
-            }
-        }
-        nodejs {
-            testTask {
-                // TODO: enable once the tests work with Kotlin/JS.
-                enabled = false
-            }
-        }
+        browser()
+        nodejs()
         binaries.executable()
     }
 

--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlScalarTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlScalarTest.kt
@@ -20,7 +20,6 @@ package com.charleskorn.kaml
 
 import io.kotest.assertions.asClue
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.assertions.withClue
 import io.kotest.common.Platform
 import io.kotest.common.platform
 import io.kotest.core.test.Enabled

--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlScalarTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlScalarTest.kt
@@ -25,6 +25,8 @@ import io.kotest.common.Platform
 import io.kotest.common.platform
 import io.kotest.core.test.Enabled
 import io.kotest.core.test.EnabledOrReasonIf
+import io.kotest.matchers.doubles.shouldBeNaN
+import io.kotest.matchers.floats.shouldBeNaN
 import io.kotest.matchers.shouldBe
 
 class YamlScalarTest : FlatFunSpec({
@@ -180,12 +182,9 @@ class YamlScalarTest : FlatFunSpec({
 
                         test("converts it to the expected double") {
                             if (expectedResult.isNaN()) {
-                                // this is not correct to compare NaNs
-                                // instead isNaN method should be invoked
-                                // to check whether the value is NaN or not
-                                withClue("$result should be NaN") {
-                                    result.isNaN() shouldBe true
-                                }
+                                // comparing NaNs requires special code
+                                // as they must not be compared via == / equals()
+                                result.shouldBeNaN()
                             } else {
                                 result shouldBe expectedResult
                             }
@@ -225,12 +224,9 @@ class YamlScalarTest : FlatFunSpec({
 
                         test("converts it to the expected float") {
                             if (expectedResult.isNaN()) {
-                                // this is not correct to compare NaNs
-                                // instead isNaN method should be invoked
-                                // to check whether the value is NaN or not
-                                withClue("$result should be NaN") {
-                                    result.isNaN() shouldBe true
-                                }
+                                // comparing NaNs requires special code
+                                // as they must not be compared via == / equals()
+                                result.shouldBeNaN()
                             } else {
                                 result shouldBe expectedResult
                             }
@@ -251,6 +247,7 @@ class YamlScalarTest : FlatFunSpec({
                 "+",
                 "",
             ).forEach { content ->
+
                 val ignoreValidFloatingPointsForJs: EnabledOrReasonIf = {
                     if (platform == Platform.JS && content in setOf("0x2", "0o2")) {
                         Enabled.disabled("$content is a valid floating value for JS due to dynamic cast")
@@ -258,6 +255,7 @@ class YamlScalarTest : FlatFunSpec({
                         Enabled.enabled
                     }
                 }
+
                 context("given a scalar with the content '$content'") {
                     val path = YamlPath.root.withListEntry(1, Location(2, 4))
                     val scalar = YamlScalar(content, path)

--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlScalarTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlScalarTest.kt
@@ -20,6 +20,11 @@ package com.charleskorn.kaml
 
 import io.kotest.assertions.asClue
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.withClue
+import io.kotest.common.Platform
+import io.kotest.common.platform
+import io.kotest.core.test.Enabled
+import io.kotest.core.test.EnabledOrReasonIf
 import io.kotest.matchers.shouldBe
 
 class YamlScalarTest : FlatFunSpec({
@@ -174,7 +179,16 @@ class YamlScalarTest : FlatFunSpec({
                         val result = scalar.toDouble()
 
                         test("converts it to the expected double") {
-                            result shouldBe expectedResult
+                            if (expectedResult.isNaN()) {
+                                // this is not correct to compare NaNs
+                                // instead isNaN method should be invoked
+                                // to check whether the value is NaN or not
+                                withClue("$result should be NaN") {
+                                    result.isNaN() shouldBe true
+                                }
+                            } else {
+                                result shouldBe expectedResult
+                            }
                         }
                     }
                 }
@@ -210,7 +224,16 @@ class YamlScalarTest : FlatFunSpec({
                         val result = scalar.toFloat()
 
                         test("converts it to the expected float") {
-                            result shouldBe expectedResult
+                            if (expectedResult.isNaN()) {
+                                // this is not correct to compare NaNs
+                                // instead isNaN method should be invoked
+                                // to check whether the value is NaN or not
+                                withClue("$result should be NaN") {
+                                    result.isNaN() shouldBe true
+                                }
+                            } else {
+                                result shouldBe expectedResult
+                            }
                         }
                     }
                 }
@@ -228,36 +251,45 @@ class YamlScalarTest : FlatFunSpec({
                 "+",
                 "",
             ).forEach { content ->
+                val ignoreValidFloatingPointsForJs: EnabledOrReasonIf = {
+                    if (platform == Platform.JS && content in setOf("0x2", "0o2")) {
+                        Enabled.disabled("$content is a valid floating value for JS due to dynamic cast")
+                    } else {
+                        Enabled.enabled
+                    }
+                }
                 context("given a scalar with the content '$content'") {
                     val path = YamlPath.root.withListEntry(1, Location(2, 4))
                     val scalar = YamlScalar(content, path)
 
                     context("retrieving the value as a float") {
-                        test("throws an appropriate exception") {
-                            val exception = shouldThrow<YamlScalarFormatException> { scalar.toFloat() }
+                        test("throws an appropriate exception")
+                            .config(enabledOrReasonIf = ignoreValidFloatingPointsForJs) {
+                                val exception = shouldThrow<YamlScalarFormatException> { scalar.toFloat() }
 
-                            exception.asClue {
-                                it.message shouldBe "Value '$content' is not a valid floating point value."
-                                it.line shouldBe 2
-                                it.column shouldBe 4
-                                it.path shouldBe path
-                                it.originalValue shouldBe content
+                                exception.asClue {
+                                    it.message shouldBe "Value '$content' is not a valid floating point value."
+                                    it.line shouldBe 2
+                                    it.column shouldBe 4
+                                    it.path shouldBe path
+                                    it.originalValue shouldBe content
+                                }
                             }
-                        }
                     }
 
                     context("retrieving the value as a double") {
-                        test("throws an appropriate exception") {
-                            val exception = shouldThrow<YamlScalarFormatException> { scalar.toDouble() }
+                        test("throws an appropriate exception")
+                            .config(enabledOrReasonIf = ignoreValidFloatingPointsForJs) {
+                                val exception = shouldThrow<YamlScalarFormatException> { scalar.toDouble() }
 
-                            exception.asClue {
-                                it.message shouldBe "Value '$content' is not a valid floating point value."
-                                it.line shouldBe 2
-                                it.column shouldBe 4
-                                it.path shouldBe path
-                                it.originalValue shouldBe content
+                                exception.asClue {
+                                    it.message shouldBe "Value '$content' is not a valid floating point value."
+                                    it.line shouldBe 2
+                                    it.column shouldBe 4
+                                    it.path shouldBe path
+                                    it.originalValue shouldBe content
+                                }
                             }
-                        }
                     }
                 }
             }


### PR DESCRIPTION
Hi, this PR allows running tests for JS targets.

The old version of tests had the following problems:
- It is incorrect to compare NaN to another NaN using `==` operator. For Java `Float.NaN == Float.NaN` returns `false` (but `Objects.equals(Float.NaN, Float.NaN)` returns `true `, which is why tests work for Java). For JS it is [a bit different](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN).
  > NaN compares unequal (via [==](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Equality), [!=](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Inequality), [===](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality), and [!==](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Strict_inequality)) to any other value — including to another NaN value.

  For NaN comparison, `equals` call was replaced with `isNaN()` method call.

- The hex and octal numbers are valid floating point numbers for JS (because under the hood Kotlin delegates conversion to JS dynamic cast). This is the `toDouble` implementation for JS platform
  ```kotlin
  public actual fun String.toDouble(): Double = (+(this.asDynamic())).unsafeCast<Double>().also {
      if (it.isNaN() && !this.isNaN() || it == 0.0 && this.isBlank())
          numberFormatError(this)
  }
  ```
  Tests for those values are ignored for JS platform.

@sschuberth please, take a look at the PR when you have time. Thank you!