### PR TITLE
fix: `Decoder` does not represent the current node correctly

### DIFF
--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlListInput.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlListInput.kt
@@ -18,6 +18,7 @@
 
 package com.charleskorn.kaml
 
+import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.CompositeDecoder
@@ -64,6 +65,13 @@ internal class YamlListInput(val list: YamlList, yaml: Yaml, context: Serializer
     override fun decodeBoolean(): Boolean = currentElementDecoder.decodeBoolean()
     override fun decodeChar(): Char = currentElementDecoder.decodeChar()
     override fun decodeEnum(enumDescriptor: SerialDescriptor): Int = currentElementDecoder.decodeEnum(enumDescriptor)
+
+    override fun <T> decodeSerializableValue(deserializer: DeserializationStrategy<T>): T {
+        if (!haveStartedReadingElements) {
+            return super.decodeSerializableValue(deserializer)
+        }
+        return currentElementDecoder.decodeSerializableValue(deserializer)
+    }
 
     private val haveStartedReadingElements: Boolean
         get() = nextElementIndex > 0

--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlMapLikeInputBase.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlMapLikeInputBase.kt
@@ -18,6 +18,7 @@
 
 package com.charleskorn.kaml
 
+import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.modules.SerializersModule
 
@@ -44,6 +45,15 @@ internal sealed class YamlMapLikeInputBase(map: YamlMap, yaml: Yaml, context: Se
     override fun decodeBoolean(): Boolean = fromCurrentValue { decodeBoolean() }
     override fun decodeChar(): Char = fromCurrentValue { decodeChar() }
     override fun decodeEnum(enumDescriptor: SerialDescriptor): Int = fromCurrentValue { decodeEnum(enumDescriptor) }
+
+    override fun <T> decodeSerializableValue(deserializer: DeserializationStrategy<T>): T {
+        if (!haveStartedReadingEntries) {
+            return super.decodeSerializableValue(deserializer)
+        }
+        return fromCurrentValue {
+            decodeSerializableValue(deserializer)
+        }
+    }
 
     protected fun <T> fromCurrentValue(action: YamlInput.() -> T): T {
         try {

--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlReadingTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlReadingTest.kt
@@ -2604,7 +2604,7 @@ class YamlReadingTest : FlatFunSpec({
 
                 test("decodes the Yaml as an ObjectContainingObjectWithCustomSerializer") {
                     result shouldBe ObjectContainingObjectWithCustomSerializer(
-                        ObjectWithCustomSerializer("cats;dogs;birds")
+                        ObjectWithCustomSerializer("cats;dogs;birds"),
                     )
                 }
             }
@@ -2753,12 +2753,12 @@ private object DecodingFromYamlNodeSerializer : KSerializer<DatabaseListing> {
 
 @Serializable
 private data class ObjectContainingObjectWithCustomSerializer(
-    val objectWithCustomSerializer: ObjectWithCustomSerializer
+    val objectWithCustomSerializer: ObjectWithCustomSerializer,
 )
 
 @Serializable(with = SerializerForObjectWithCustomSerializer::class)
 private data class ObjectWithCustomSerializer(
-    val combinedValues: String
+    val combinedValues: String,
 )
 
 private object SerializerForObjectWithCustomSerializer : KSerializer<ObjectWithCustomSerializer> {

--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlReadingTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlReadingTest.kt
@@ -2724,10 +2724,7 @@ private object DecodingFromYamlNodeSerializer : KSerializer<DatabaseListing> {
     override fun deserialize(decoder: Decoder): DatabaseListing {
         check(decoder is YamlInput)
 
-        val currentMap = decoder.node.yamlMap.get<YamlMap>("databaseListing")
-        checkNotNull(currentMap)
-
-        val list = currentMap.entries.map { (_, value) ->
+        val list = decoder.node.yamlMap.entries.map { (_, value) ->
             decoder.yaml.decodeFromYamlNode(Database.serializer(), value)
         }
 


### PR DESCRIPTION
First bug from https://github.com/charleskorn/kaml/pull/607

> Previously the `node` property on the decoders was not traversed in deep YAML trees (e.g. with `YamlMapLikeInputBase` and `YamlListInput`). This behaviour is different from the JSON serialization library and makes it impossible to implement a content based polymorphic `KSerializer` in a meaningful way without knowing of the whole YAML tree. See also the `DecodingFromYamlNodeSerializer` in `YamlReadingTest.kt` for an affected case