### PR TITLE
fix: use serializers from the module in `decodeFromYamlNode`

### DIFF
--- a/src/commonMain/kotlin/com/charleskorn/kaml/Yaml.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/Yaml.kt
@@ -52,9 +52,6 @@ public class Yaml(
         return input.decodeSerializableValue(deserializer)
     }
 
-    public inline fun <reified T> decodeFromString(string: String): T =
-        decodeFromString(serializersModule.serializer<T>(), string)
-
     override fun <T> decodeFromString(
         deserializer: DeserializationStrategy<T>,
         string: String,
@@ -97,9 +94,6 @@ public class Yaml(
     ) {
         encodeToBufferedSink(serializer, value, sink.buffer())
     }
-
-    public inline fun <reified T> encodeToString(value: T): String =
-        encodeToString(serializersModule.serializer<T>(), value)
 
     override fun <T> encodeToString(
         serializer: SerializationStrategy<T>,

--- a/src/commonMain/kotlin/com/charleskorn/kaml/Yaml.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/Yaml.kt
@@ -42,7 +42,7 @@ public class Yaml(
     }
 
     public inline fun <reified T> decodeFromYamlNode(node: YamlNode): T =
-        decodeFromYamlNode(serializer<T>(), node)
+        decodeFromYamlNode(serializersModule.serializer<T>(), node)
 
     public fun <T> decodeFromYamlNode(
         deserializer: DeserializationStrategy<T>,


### PR DESCRIPTION
This is a fixup for 45a455c400cef16868070da7c0ac283dba08ebbe.