### PR TITLE
deps: update Kotlin to 2.1.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,6 +93,9 @@ kotlin {
                 implementation("io.kotest:kotest-assertions-core:6.0.0.M1")
                 implementation("io.kotest:kotest-framework-api:6.0.0.M1")
                 implementation("io.kotest:kotest-framework-engine:6.0.0.M1")
+                // Overridig coroutines' version to solve a problem with WASM JS tests.
+                // See https://kotlinlang.slack.com/archives/CDFP59223/p1736191408326039?thread_ts=1734964013.996149&cid=CDFP59223
+                runtimeOnly("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
             }
         }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,6 @@ group = "com.charleskorn.kaml"
 
 repositories {
     mavenCentral()
-    maven(url = "https://s01.oss.sonatype.org/content/repositories/snapshots")
 }
 
 kotlin {
@@ -91,14 +90,18 @@ kotlin {
 
         commonTest {
             dependencies {
-                implementation("io.kotest:kotest-assertions-core:6.0.0.1821-SNAPSHOT")
-                implementation("io.kotest:kotest-framework-engine:6.0.0.1821-SNAPSHOT")
+                implementation("io.kotest:kotest-assertions-core:6.0.0.M1")
+                implementation("io.kotest:kotest-framework-api:6.0.0.M1")
+                implementation("io.kotest:kotest-framework-engine:6.0.0.M1")
+                // Overridig coroutines' version to solve a problem with WASM JS tests.
+                // See https://kotlinlang.slack.com/archives/CDFP59223/p1736191408326039?thread_ts=1734964013.996149&cid=CDFP59223
+                runtimeOnly("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
             }
         }
 
         jvmTest {
             dependencies {
-                implementation("io.kotest:kotest-runner-junit5:6.0.0.1821-SNAPSHOT")
+                implementation("io.kotest:kotest-runner-junit5:6.0.0.M1")
             }
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,7 @@ group = "com.charleskorn.kaml"
 
 repositories {
     mavenCentral()
+    maven(url = "https://s01.oss.sonatype.org/content/repositories/snapshots")
 }
 
 kotlin {
@@ -90,18 +91,14 @@ kotlin {
 
         commonTest {
             dependencies {
-                implementation("io.kotest:kotest-assertions-core:6.0.0.M1")
-                implementation("io.kotest:kotest-framework-api:6.0.0.M1")
-                implementation("io.kotest:kotest-framework-engine:6.0.0.M1")
-                // Overridig coroutines' version to solve a problem with WASM JS tests.
-                // See https://kotlinlang.slack.com/archives/CDFP59223/p1736191408326039?thread_ts=1734964013.996149&cid=CDFP59223
-                runtimeOnly("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
+                implementation("io.kotest:kotest-assertions-core:6.0.0.1821-SNAPSHOT")
+                implementation("io.kotest:kotest-framework-engine:6.0.0.1821-SNAPSHOT")
             }
         }
 
         jvmTest {
             dependencies {
-                implementation("io.kotest:kotest-runner-junit5:6.0.0.M1")
+                implementation("io.kotest:kotest-runner-junit5:6.0.0.1821-SNAPSHOT")
             }
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,7 +93,7 @@ kotlin {
                 implementation("io.kotest:kotest-assertions-core:6.0.0.M1")
                 implementation("io.kotest:kotest-framework-api:6.0.0.M1")
                 implementation("io.kotest:kotest-framework-engine:6.0.0.M1")
-                // Overridig coroutines' version to solve a problem with WASM JS tests.
+                // Overriding coroutines' version to solve a problem with WASM JS tests.
                 // See https://kotlinlang.slack.com/archives/CDFP59223/p1736191408326039?thread_ts=1734964013.996149&cid=CDFP59223
                 runtimeOnly("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
             }

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -104,23 +104,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/eslint-scope@^3.7.3":
-  version "3.7.7"
-  resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.7.tgz#3108bd5f18b0cdb277c867b3dd449c9ed7079ac5"
-  integrity sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==
-  dependencies:
-    "@types/eslint" "*"
-    "@types/estree" "*"
-
-"@types/eslint@*":
-  version "8.56.10"
-  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-8.56.10.tgz#eb2370a73bf04a901eeba8f22595c7ee0f7eb58d"
-  integrity sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==
-  dependencies:
-    "@types/estree" "*"
-    "@types/json-schema" "*"
-
-"@types/estree@*", "@types/estree@^1.0.5":
+"@types/estree@^1.0.5":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.5.tgz#a6ce3e556e00fd9895dd872dd172ad0d4bd687f4"
   integrity sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==
@@ -157,7 +141,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/json-schema@*", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
+"@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
   version "7.0.15"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
@@ -903,7 +887,7 @@ engine.io@~6.5.2:
     engine.io-parser "~5.2.1"
     ws "~8.11.0"
 
-enhanced-resolve@^5.17.0:
+enhanced-resolve@^5.17.1:
   version "5.17.1"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz#67bfbbcc2f81d511be77d686a90267ef7f898a15"
   integrity sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==
@@ -1576,10 +1560,10 @@ karma-webpack@5.0.1:
     minimatch "^9.0.3"
     webpack-merge "^4.1.5"
 
-karma@6.4.3:
-  version "6.4.3"
-  resolved "https://registry.yarnpkg.com/karma/-/karma-6.4.3.tgz#763e500f99597218bbb536de1a14acc4ceea7ce8"
-  integrity sha512-LuucC/RE92tJ8mlCwqEoRWXP38UMAqpnq98vktmS9SznSoUPPUJQbc91dHcxcunROvfQjdORVA/YFviH+Xci9Q==
+karma@6.4.4:
+  version "6.4.4"
+  resolved "https://registry.yarnpkg.com/karma/-/karma-6.4.4.tgz#dfa5a426cf5a8b53b43cd54ef0d0d09742351492"
+  integrity sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==
   dependencies:
     "@colors/colors" "1.5.0"
     body-parser "^1.19.0"
@@ -1610,6 +1594,13 @@ kind-of@^6.0.2:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
+
+kotlin-web-helpers@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/kotlin-web-helpers/-/kotlin-web-helpers-2.0.0.tgz#b112096b273c1e733e0b86560998235c09a19286"
+  integrity sha512-xkVGl60Ygn/zuLkDPx+oHj7jeLR7hCvoNF99nhwXMn8a3ApB4lLiC9pk4ol4NHPjyoCbvQctBqvzUcp8pkqyWw==
+  dependencies:
+    format-util "^1.0.5"
 
 launch-editor@^2.6.0:
   version "2.9.1"
@@ -1762,10 +1753,10 @@ mkdirp@^0.5.5:
   dependencies:
     minimist "^1.2.6"
 
-mocha@10.7.0:
-  version "10.7.0"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.7.0.tgz#9e5cbed8fa9b37537a25bd1f7fb4f6fc45458b9a"
-  integrity sha512-v8/rBWr2VO5YkspYINnvu81inSz2y3ODJrhO175/Exzor1RcEZZkizgE2A+w/CAXXoESS8Kys5E62dOHGHzULA==
+mocha@10.7.3:
+  version "10.7.3"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.7.3.tgz#ae32003cabbd52b59aece17846056a68eb4b0752"
+  integrity sha512-uQWxAu44wwiACGqjbPYmjo7Lg8sFrS3dQe7PP2FQI+woptP4vZXSMcfMyFL/e1yFEeEpV4RtyTpZROOKmxis+A==
   dependencies:
     ansi-colors "^4.1.3"
     browser-stdout "^1.3.1"
@@ -2674,12 +2665,11 @@ webpack-sources@^3.2.3:
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
-webpack@5.93.0:
-  version "5.93.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.93.0.tgz#2e89ec7035579bdfba9760d26c63ac5c3462a5e5"
-  integrity sha512-Y0m5oEY1LRuwly578VqluorkXbvXKh7U3rLoQCEO04M97ScRr44afGVkI0FQFsXzysk5OgFAxjZAb9rsGQVihA==
+webpack@5.94.0:
+  version "5.94.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.94.0.tgz#77a6089c716e7ab90c1c67574a28da518a20970f"
+  integrity sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==
   dependencies:
-    "@types/eslint-scope" "^3.7.3"
     "@types/estree" "^1.0.5"
     "@webassemblyjs/ast" "^1.12.1"
     "@webassemblyjs/wasm-edit" "^1.12.1"
@@ -2688,7 +2678,7 @@ webpack@5.93.0:
     acorn-import-attributes "^1.9.5"
     browserslist "^4.21.10"
     chrome-trace-event "^1.0.2"
-    enhanced-resolve "^5.17.0"
+    enhanced-resolve "^5.17.1"
     es-module-lexer "^1.2.1"
     eslint-scope "5.1.1"
     events "^3.2.0"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,7 +20,7 @@ rootProject.name = "kaml"
 
 pluginManagement {
     plugins {
-        kotlin("multiplatform") version "2.0.21"
-        kotlin("plugin.serialization") version "2.0.21"
+        kotlin("multiplatform") version "2.1.0"
+        kotlin("plugin.serialization") version "2.1.0"
     }
 }

--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlScalarTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlScalarTest.kt
@@ -16,16 +16,10 @@
 
 */
 
-// It's not clear what is the external API to make some tests conditional.
-// Since we're using a snapshot version of kotest, let's opt in for now,
-// hoping that we'll find the answer before onboarding a proper 6.0.0 version.
-@file:OptIn(KotestInternal::class)
-
 package com.charleskorn.kaml
 
 import io.kotest.assertions.asClue
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.common.KotestInternal
 import io.kotest.core.test.Enabled.Companion.disabled
 import io.kotest.core.test.Enabled.Companion.enabled
 import io.kotest.core.test.EnabledOrReasonIf

--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlScalarTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlScalarTest.kt
@@ -16,10 +16,16 @@
 
 */
 
+// It's not clear what is the external API to make some tests conditional.
+// Since we're using a snapshot version of kotest, let's opt in for now,
+// hoping that we'll find the answer before onboarding a proper 6.0.0 version.
+@file:OptIn(KotestInternal::class)
+
 package com.charleskorn.kaml
 
 import io.kotest.assertions.asClue
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.common.KotestInternal
 import io.kotest.core.test.Enabled.Companion.disabled
 import io.kotest.core.test.Enabled.Companion.enabled
 import io.kotest.core.test.EnabledOrReasonIf


### PR DESCRIPTION
It's actually https://github.com/charleskorn/kaml/pull/646, but with a workaround for an issue related to coroutines in the tests.