### PR TITLE
fix(internal): handle `descriptor.isInline` correctly in `YamlInput.Companion.createFor`

### DIFF
--- a/src/commonTest/kotlin/com/charleskorn/kaml/TestInlineTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/TestInlineTest.kt
@@ -1,0 +1,152 @@
+/*
+
+   Copyright 2018-2023 Charles Korn.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+*/
+
+package com.charleskorn.kaml
+
+import com.charleskorn.kaml.testobjects.TestInline
+import com.charleskorn.kaml.testobjects.TestSealedImpl
+import com.charleskorn.kaml.testobjects.TestSealedInterface
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.serializer
+
+class TestInlineTest : FlatFunSpec({
+    context("given a TestInline value class") {
+        context("with a string value") {
+            val value = TestInline("hello")
+            val yaml = "\"hello\""
+
+            test("serializing it to YAML produces the expected output") {
+                val result = Yaml.default.encodeToString(TestInline.serializer(String.serializer()), value)
+                result shouldBe yaml
+            }
+
+            test("deserializing it from YAML produces the expected object") {
+                val result = Yaml.default.decodeFromString(TestInline.serializer(String.serializer()), yaml)
+                result shouldBe value
+            }
+        }
+
+        context("with an integer value") {
+            val value = TestInline(123)
+            val yaml = "123"
+
+            test("serializing it to YAML produces the expected output") {
+                val result = Yaml.default.encodeToString(TestInline.serializer(Int.serializer()), value)
+                result shouldBe yaml
+            }
+
+            test("deserializing it from YAML produces the expected object") {
+                val result = Yaml.default.decodeFromString(TestInline.serializer(Int.serializer()), yaml)
+                result shouldBe value
+            }
+        }
+
+        context("with a boolean value") {
+            val value = TestInline(true)
+            val yaml = "true"
+
+            test("serializing it to YAML produces the expected output") {
+                val result = Yaml.default.encodeToString(TestInline.serializer(Boolean.serializer()), value)
+                result shouldBe yaml
+            }
+
+            test("deserializing it from YAML produces the expected object") {
+                val result = Yaml.default.decodeFromString(TestInline.serializer(Boolean.serializer()), yaml)
+                result shouldBe value
+            }
+        }
+
+        context("with a double value") {
+            val value = TestInline(3.14)
+            val yaml = "3.14"
+
+            test("serializing it to YAML produces the expected output") {
+                val result = Yaml.default.encodeToString(TestInline.serializer(Double.serializer()), value)
+                result shouldBe yaml
+            }
+
+            test("deserializing it from YAML produces the expected object") {
+                val result = Yaml.default.decodeFromString(TestInline.serializer(Double.serializer()), yaml)
+                result shouldBe value
+            }
+        }
+
+        context("with a list value") {
+            @Serializable
+            data class TestList(val items: List<Int>)
+
+            val testList = TestList(listOf(1, 2))
+            val value = TestInline(testList)
+            val yaml = """
+                items:
+                - 1
+                - 2
+            """.trimIndent()
+
+            test("serializing it to YAML produces the expected output") {
+                val result = Yaml.default.encodeToString(TestInline.serializer(TestList.serializer()), value)
+                result shouldBe yaml
+            }
+
+            test("deserializing it from YAML produces the expected object") {
+                val result = Yaml.default.decodeFromString(TestInline.serializer(TestList.serializer()), yaml)
+                result shouldBe value
+            }
+        }
+
+        context("with a map value") {
+            @Serializable
+            data class TestMap(val map: Map<String, Int>)
+
+            val testMap = TestMap(mapOf("key1" to 1, "key2" to 2))
+            val value = TestInline(testMap)
+            val yaml = """
+                map:
+                  "key1": 1
+                  "key2": 2
+            """.trimIndent()
+
+            test("serializing it to YAML produces the expected output") {
+                val result = Yaml.default.encodeToString(TestInline.serializer(TestMap.serializer()), value)
+                result shouldBe yaml
+            }
+
+            test("deserializing it from YAML produces the expected object") {
+                val result = Yaml.default.decodeFromString(TestInline.serializer(TestMap.serializer()), yaml)
+                result shouldBe value
+            }
+        }
+
+        context("with a tagged node") {
+            val value = TestInline(TestSealedImpl("hello"))
+            val yaml = """
+                !<com.charleskorn.kaml.testobjects.TestSealedImpl>
+                value: "hello"
+            """.trimIndent()
+            test("serializing it to YAML produces the expected output") {
+                val result = Yaml.default.encodeToString(TestInline.serializer(TestSealedInterface.serializer()), value)
+                result shouldBe yaml
+            }
+            test("deserializing it from YAML produces the expected object") {
+                val result = Yaml.default.decodeFromString(TestInline.serializer(TestSealedInterface.serializer()), yaml)
+                result shouldBe value
+            }
+        }
+    }
+})

--- a/src/commonTest/kotlin/com/charleskorn/kaml/testobjects/TestObjects.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/testobjects/TestObjects.kt
@@ -26,6 +26,7 @@ import com.charleskorn.kaml.YamlScalar
 import com.charleskorn.kaml.YamlTaggedNode
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmInline
 
 @Serializable
 data class SimpleStructure(
@@ -96,3 +97,13 @@ data class TestClassWithNestedTaggedNode(
     val text: String,
     val node: YamlTaggedNode,
 )
+
+@Serializable
+@JvmInline
+value class TestInline<out T>(val value: T)
+
+@Serializable
+sealed interface TestSealedInterface
+
+@Serializable
+data class TestSealedImpl(val value: String) : TestSealedInterface


### PR DESCRIPTION
Fix issue #694 

Handle `descriptor.isInline` correctly in `YamlInput.Companion.createFor` and add tests for inline classes.

All tests passed.