### PR TITLE
feat: expose YamlScalar to...OrNull functions

### DIFF
--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlNode.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlNode.kt
@@ -86,7 +86,7 @@ public data class YamlScalar(val content: String, override val path: YamlPath) :
             ?: throw YamlScalarFormatException("Value '$content' is not a valid floating point value.", path, content)
     }
 
-    internal fun toDoubleOrNull(): Double? {
+    public fun toDoubleOrNull(): Double? {
         return when (content) {
             ".inf", ".Inf", ".INF" -> Double.POSITIVE_INFINITY
             "-.inf", "-.Inf", "-.INF" -> Double.NEGATIVE_INFINITY
@@ -109,7 +109,7 @@ public data class YamlScalar(val content: String, override val path: YamlPath) :
             ?: throw YamlScalarFormatException("Value '$content' is not a valid boolean, permitted choices are: true or false", path, content)
     }
 
-    internal fun toBooleanOrNull(): Boolean? {
+    public fun toBooleanOrNull(): Boolean? {
         return when (content) {
             "true", "True", "TRUE" -> true
             "false", "False", "FALSE" -> false
@@ -119,7 +119,7 @@ public data class YamlScalar(val content: String, override val path: YamlPath) :
 
     public fun toChar(): Char = toCharOrNull() ?: throw YamlScalarFormatException("Value '$content' is not a valid character value.", path, content)
 
-    internal fun toCharOrNull(): Char? = content.singleOrNull()
+    public fun toCharOrNull(): Char? = content.singleOrNull()
 
     override fun withPath(newPath: YamlPath): YamlScalar = this.copy(path = newPath)
 


### PR DESCRIPTION
To avoid things like
```kotlin
runCatching { yaml.toDouble() }.map { SimpleDataValue(SimpleDataLayout.Float, it) }.getOrNull() ?:
runCatching { yaml.toInt() }.map { SimpleDataValue(SimpleDataLayout.Integer, it) }.getOrNull() ?:
runCatching { yaml.toBoolean() }.map { SimpleDataValue(SimpleDataLayout.Boolean, it) }.getOrNull() ?:
SimpleDataValue(SimpleDataLayout.String, yaml.content)
```
which I sadly have to use currently, expose the `to...OrNull` functions of the `YamlScalar` class.

Imho, exposing those doesn't have any disadvantage.
The only advantage is, that users can decide for themselves if they want to get null of the scalar if it is not a double, int, etc., or an exception. Same as with `kotlin.String` for example.