### PR TITLE
feat: Preserve scalar styles and YAML tags when serializing YamlNode

### DIFF
--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlNode.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlNode.kt
@@ -18,6 +18,7 @@
 
 package com.charleskorn.kaml
 
+import it.krzeminski.snakeyaml.engine.kmp.common.ScalarStyle
 import kotlinx.serialization.Serializable
 
 @Serializable(with = YamlNodeSerializer::class)
@@ -34,7 +35,7 @@ public sealed class YamlNode(public open val path: YamlPath) {
 }
 
 @Serializable(with = YamlScalarSerializer::class)
-public data class YamlScalar(val content: String, override val path: YamlPath) : YamlNode(path) {
+public data class YamlScalar(val content: String, override val path: YamlPath, val scalarStyle: YamlNodeScalarStyle? = null) : YamlNode(path) {
     override fun equivalentContentTo(other: YamlNode): Boolean = other is YamlScalar && this.content == other.content
     override fun contentToString(): String = "'$content'"
 

--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlNode.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlNode.kt
@@ -18,7 +18,6 @@
 
 package com.charleskorn.kaml
 
-import it.krzeminski.snakeyaml.engine.kmp.common.ScalarStyle
 import kotlinx.serialization.Serializable
 
 @Serializable(with = YamlNodeSerializer::class)

--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlNodeReader.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlNodeReader.kt
@@ -72,7 +72,7 @@ internal class YamlNodeReader(
         if ((event.value == "null" || event.value == "" || event.value == "~") && event.plain) {
             return YamlNull(path)
         } else {
-            return YamlScalar(event.value, path)
+            return YamlScalar(event.value, path, YamlNodeScalarStyle.fromScalarStyle(event.scalarStyle))
         }
     }
 
@@ -114,7 +114,7 @@ internal class YamlNodeReader(
                 else -> {
                     val keyLocation = parser.peekEvent(path).location
                     val key = readMapKey(path)
-                    val keyNode = YamlScalar(key, path.withMapElementKey(key, keyLocation))
+                    val keyNode = YamlScalar(key, path.withMapElementKey(key, keyLocation), YamlNodeScalarStyle.PLAIN)
 
                     val valueLocation = parser.peekEvent(keyNode.path).location
                     val valuePath = if (isMerge(keyNode)) path.withMerge(valueLocation) else keyNode.path.withMapElementValue(valueLocation)

--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlNodeScalarStyle.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlNodeScalarStyle.kt
@@ -26,7 +26,8 @@ public enum class YamlNodeScalarStyle {
     LITERAL,
     FOLDED,
     JSON_SCALAR_STYLE,
-    PLAIN;
+    PLAIN,
+    ;
 
     public fun toScalarStyle(): ScalarStyle = when (this) {
         DOUBLE_QUOTED -> ScalarStyle.DOUBLE_QUOTED

--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlNodeScalarStyle.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlNodeScalarStyle.kt
@@ -1,0 +1,50 @@
+/*
+
+   Copyright 2018-2023 Charles Korn.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+*/
+
+package com.charleskorn.kaml
+
+import it.krzeminski.snakeyaml.engine.kmp.common.ScalarStyle
+
+public enum class YamlNodeScalarStyle {
+    DOUBLE_QUOTED,
+    SINGLE_QUOTED,
+    LITERAL,
+    FOLDED,
+    JSON_SCALAR_STYLE,
+    PLAIN;
+
+    public fun toScalarStyle(): ScalarStyle = when (this) {
+        DOUBLE_QUOTED -> ScalarStyle.DOUBLE_QUOTED
+        SINGLE_QUOTED -> ScalarStyle.SINGLE_QUOTED
+        LITERAL -> ScalarStyle.LITERAL
+        FOLDED -> ScalarStyle.FOLDED
+        JSON_SCALAR_STYLE -> ScalarStyle.JSON_SCALAR_STYLE
+        PLAIN -> ScalarStyle.PLAIN
+    }
+
+    public companion object {
+        public fun fromScalarStyle(scalarStyle: ScalarStyle): YamlNodeScalarStyle = when (scalarStyle) {
+            ScalarStyle.DOUBLE_QUOTED -> DOUBLE_QUOTED
+            ScalarStyle.SINGLE_QUOTED -> SINGLE_QUOTED
+            ScalarStyle.LITERAL -> LITERAL
+            ScalarStyle.FOLDED -> FOLDED
+            ScalarStyle.JSON_SCALAR_STYLE -> JSON_SCALAR_STYLE
+            ScalarStyle.PLAIN -> PLAIN
+        }
+    }
+}

--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlNodeSerializer.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlNodeSerializer.kt
@@ -44,14 +44,7 @@ internal object YamlNodeSerializer : KSerializer<YamlNode> {
         }.nullable
 
     override fun serialize(encoder: Encoder, value: YamlNode) {
-        encoder.asYamlOutput()
-        when (value) {
-            is YamlList -> encoder.encodeSerializableValue(YamlListSerializer, value)
-            is YamlMap -> encoder.encodeSerializableValue(YamlMapSerializer, value)
-            is YamlNull -> encoder.encodeSerializableValue(YamlNullSerializer, value)
-            is YamlScalar -> encoder.encodeSerializableValue(YamlScalarSerializer, value)
-            is YamlTaggedNode -> encoder.encodeSerializableValue(YamlTaggedNodeSerializer, value)
-        }
+        encoder.asYamlOutput().encodeYamlNode(value)
     }
 
     override fun deserialize(decoder: Decoder): YamlNode {
@@ -65,12 +58,7 @@ internal object YamlScalarSerializer : KSerializer<YamlScalar> {
         PrimitiveSerialDescriptor("com.charleskorn.kaml.YamlScalar", PrimitiveKind.STRING)
 
     override fun serialize(encoder: Encoder, value: YamlScalar) {
-        encoder.asYamlOutput()
-        value.toBooleanOrNull()?.also { return encoder.encodeBoolean(it) }
-        value.toLongOrNull()?.also { return encoder.encodeLong(it) }
-        value.toDoubleOrNull()?.also { return encoder.encodeDouble(it) }
-        value.toCharOrNull()?.also { return encoder.encodeChar(it) }
-        encoder.encodeString(value.content)
+        encoder.asYamlOutput().encodeYamlScalar(value)
     }
 
     override fun deserialize(decoder: Decoder): YamlScalar {
@@ -96,16 +84,10 @@ internal object YamlNullSerializer : KSerializer<YamlNull> {
 internal object YamlTaggedNodeSerializer : KSerializer<YamlTaggedNode> {
 
     override val descriptor: SerialDescriptor =
-        buildSerialDescriptor("com.charleskorn.kaml.YamlTaggedNode", PolymorphicKind.OPEN) {
-            element("tag", String.serializer().descriptor)
-            element("node", YamlNodeSerializer.descriptor)
-        }
+        buildSerialDescriptor("com.charleskorn.kaml.YamlTaggedNode", PolymorphicKind.SEALED) {}
 
     override fun serialize(encoder: Encoder, value: YamlTaggedNode) {
-        encoder.asYamlOutput().encodeStructure(descriptor) {
-            encodeStringElement(descriptor, 0, value.tag)
-            encodeSerializableElement(descriptor, 1, YamlNodeSerializer, value.innerNode)
-        }
+        encoder.asYamlOutput().encodeYamlTaggedNode(value)
     }
 
     override fun deserialize(decoder: Decoder): YamlTaggedNode {
@@ -118,8 +100,7 @@ internal object YamlMapSerializer : KSerializer<YamlMap> {
     override val descriptor: SerialDescriptor = MapSerializer(YamlScalarSerializer, YamlNodeSerializer).descriptor
 
     override fun serialize(encoder: Encoder, value: YamlMap) {
-        encoder.asYamlOutput()
-        MapSerializer(YamlScalarSerializer, YamlNodeSerializer).serialize(encoder, value.entries)
+        encoder.asYamlOutput().encodeYamlMap(value)
     }
 
     override fun deserialize(decoder: Decoder): YamlMap {
@@ -132,8 +113,7 @@ internal object YamlListSerializer : KSerializer<YamlList> {
     override val descriptor: SerialDescriptor = ListSerializer(YamlNodeSerializer).descriptor
 
     override fun serialize(encoder: Encoder, value: YamlList) {
-        encoder.asYamlOutput()
-        ListSerializer(YamlNodeSerializer).serialize(encoder, value.items)
+        encoder.asYamlOutput().encodeYamlList(value)
     }
 
     override fun deserialize(decoder: Decoder): YamlList {

--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlNodeSerializer.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlNodeSerializer.kt
@@ -25,7 +25,6 @@ import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.MapSerializer
-import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.descriptors.PolymorphicKind
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -35,7 +34,6 @@ import kotlinx.serialization.descriptors.buildSerialDescriptor
 import kotlinx.serialization.descriptors.nullable
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
-import kotlinx.serialization.encoding.encodeStructure
 
 internal object YamlNodeSerializer : KSerializer<YamlNode> {
     override val descriptor: SerialDescriptor =

--- a/src/commonMain/kotlin/com/charleskorn/kaml/YamlOutput.kt
+++ b/src/commonMain/kotlin/com/charleskorn/kaml/YamlOutput.kt
@@ -99,11 +99,11 @@ internal class YamlOutput(
         val multiLineScalarStyle = forcedMultiLineScalarStyle ?.scalarStyle ?: configuration.multiLineStringStyle.scalarStyle
         return when {
             value.contains('\n')
-                -> multiLineScalarStyle
+            -> multiLineScalarStyle
             configuration.singleLineStringStyle == SingleLineStringStyle.PlainExceptAmbiguous && value.isAmbiguous()
-                -> configuration.ambiguousQuoteStyle.scalarStyle
+            -> configuration.ambiguousQuoteStyle.scalarStyle
             else
-                -> singleLineScalarStyle
+            -> singleLineScalarStyle
         }
     }
 
@@ -281,9 +281,9 @@ internal class YamlOutput(
         val implicit = if (tag != null) ALL_EXPLICIT else ALL_IMPLICIT
         val style = when {
             value.scalarStyle != null -> value.scalarStyle.toScalarStyle()
-            value.toBooleanOrNull() != null
-                || value.toLongOrNull() != null
-                || value.toDoubleOrNull() != null -> ScalarStyle.PLAIN
+            value.toBooleanOrNull() != null ||
+                value.toLongOrNull() != null ||
+                value.toDoubleOrNull() != null -> ScalarStyle.PLAIN
             value.toCharOrNull() != null -> configuration.singleLineStringStyle.scalarStyle
             else -> determineScalarStyle(value.content)
         }

--- a/src/commonTest/kotlin/com/charleskorn/kaml/YamlWritingTest.kt
+++ b/src/commonTest/kotlin/com/charleskorn/kaml/YamlWritingTest.kt
@@ -872,9 +872,9 @@ class YamlWritingTest : FlatFunSpec({
             val expectedOutput = """
                     text: "test"
                     node:
-                      "foo": "bar"
-                      "baz": 1
-                      "test":
+                      foo: bar
+                      baz: 1
+                      test:
                       - 1
                       - 2
                       - 3
@@ -1274,7 +1274,7 @@ class YamlWritingTest : FlatFunSpec({
             val node = Yaml.default.parseToYamlNode("!testtag 2024-01-01") as YamlTaggedNode
             val expectedOutput = """
                     text: "test"
-                    node: !testtag "2024-01-01"
+                    node: !testtag '2024-01-01'
             """.trimIndent()
             context("as tagged node") {
                 val value = TestClassWithNestedTaggedNode(text = "test", node = node)
@@ -1366,6 +1366,500 @@ class YamlWritingTest : FlatFunSpec({
                         # multiline
                         test: "justTest"
                     """.trimIndent()
+                }
+            }
+        }
+
+        context("serializing YamlNode preserving string types and tags") {
+            context("preserving boolean-like strings") {
+                context("double-quoted string 'false'") {
+                    val inputYaml = """"false""""
+                    val node = Yaml.default.parseToYamlNode(inputYaml)
+                    val output = Yaml.default.encodeToString(YamlNodeSerializer, node)
+
+                    test("preserves the string and does not convert to boolean") {
+                        output shouldBe """"false""""
+                    }
+                }
+
+                context("double-quoted string 'true'") {
+                    val inputYaml = """"true""""
+                    val node = Yaml.default.parseToYamlNode(inputYaml)
+                    val output = Yaml.default.encodeToString(YamlNodeSerializer, node)
+
+                    test("preserves the string and does not convert to boolean") {
+                        output shouldBe """"true""""
+                    }
+                }
+
+                context("double-quoted string 'TRUE'") {
+                    val inputYaml = """"TRUE""""
+                    val node = Yaml.default.parseToYamlNode(inputYaml)
+                    val output = Yaml.default.encodeToString(YamlNodeSerializer, node)
+
+                    test("preserves the string with original casing") {
+                        output shouldBe """"TRUE""""
+                    }
+                }
+
+                context("double-quoted string 'False'") {
+                    val inputYaml = """"False""""
+                    val node = Yaml.default.parseToYamlNode(inputYaml)
+                    val output = Yaml.default.encodeToString(YamlNodeSerializer, node)
+
+                    test("preserves the string with original casing") {
+                        output shouldBe """"False""""
+                    }
+                }
+
+                context("single-quoted string 'false'") {
+                    val inputYaml = """'false'"""
+                    val node = Yaml.default.parseToYamlNode(inputYaml)
+                    val output = Yaml.default.encodeToString(YamlNodeSerializer, node)
+
+                    test("preserves the string and does not convert to boolean") {
+                        output shouldBe """'false'"""
+                    }
+                }
+
+                context("single-quoted string 'true'") {
+                    val inputYaml = """'true'"""
+                    val node = Yaml.default.parseToYamlNode(inputYaml)
+                    val output = Yaml.default.encodeToString(YamlNodeSerializer, node)
+
+                    test("preserves the string and does not convert to boolean") {
+                        output shouldBe """'true'"""
+                    }
+                }
+            }
+
+            context("preserving number-like strings") {
+                context("double-quoted phone number string") {
+                    val inputYaml = """"+44123456""""
+                    val node = Yaml.default.parseToYamlNode(inputYaml)
+                    val output = Yaml.default.encodeToString(YamlNodeSerializer, node)
+
+                    test("preserves the string with leading plus sign") {
+                        output shouldBe """"+44123456""""
+                    }
+                }
+
+                context("double-quoted integer string '123'") {
+                    val inputYaml = """"123""""
+                    val node = Yaml.default.parseToYamlNode(inputYaml)
+                    val output = Yaml.default.encodeToString(YamlNodeSerializer, node)
+
+                    test("preserves the string and does not convert to integer") {
+                        output shouldBe """"123""""
+                    }
+                }
+
+                context("double-quoted hex string '0x123'") {
+                    val inputYaml = """"0x123""""
+                    val node = Yaml.default.parseToYamlNode(inputYaml)
+                    val output = Yaml.default.encodeToString(YamlNodeSerializer, node)
+
+                    test("preserves the string and does not convert to hex number") {
+                        output shouldBe """"0x123""""
+                    }
+                }
+
+                context("double-quoted octal string '0o777'") {
+                    val inputYaml = """"0o777""""
+                    val node = Yaml.default.parseToYamlNode(inputYaml)
+                    val output = Yaml.default.encodeToString(YamlNodeSerializer, node)
+
+                    test("preserves the string and does not convert to octal number") {
+                        output shouldBe """"0o777""""
+                    }
+                }
+
+                context("single-quoted integer string '456'") {
+                    val inputYaml = """'456'"""
+                    val node = Yaml.default.parseToYamlNode(inputYaml)
+                    val output = Yaml.default.encodeToString(YamlNodeSerializer, node)
+
+                    test("preserves the string and does not convert to integer") {
+                        output shouldBe """'456'"""
+                    }
+                }
+
+                context("double-quoted negative number string '-42'") {
+                    val inputYaml = """"-42""""
+                    val node = Yaml.default.parseToYamlNode(inputYaml)
+                    val output = Yaml.default.encodeToString(YamlNodeSerializer, node)
+
+                    test("preserves the string and does not convert to negative integer") {
+                        output shouldBe """"-42""""
+                    }
+                }
+            }
+
+            context("preserving float-like strings") {
+                context("double-quoted float string '1.2'") {
+                    val inputYaml = """"1.2""""
+                    val node = Yaml.default.parseToYamlNode(inputYaml)
+                    val output = Yaml.default.encodeToString(YamlNodeSerializer, node)
+
+                    test("preserves the string and does not convert to float") {
+                        output shouldBe """"1.2""""
+                    }
+                }
+
+                context("double-quoted float string '3.14'") {
+                    val inputYaml = """"3.14""""
+                    val node = Yaml.default.parseToYamlNode(inputYaml)
+                    val output = Yaml.default.encodeToString(YamlNodeSerializer, node)
+
+                    test("preserves the string and does not convert to float") {
+                        output shouldBe """"3.14""""
+                    }
+                }
+
+                context("double-quoted infinity string '.inf'") {
+                    val inputYaml = """".inf""""
+                    val node = Yaml.default.parseToYamlNode(inputYaml)
+                    val output = Yaml.default.encodeToString(YamlNodeSerializer, node)
+
+                    test("preserves the string and does not convert to infinity") {
+                        output shouldBe """".inf""""
+                    }
+                }
+
+                context("double-quoted NaN string '.nan'") {
+                    val inputYaml = """".nan""""
+                    val node = Yaml.default.parseToYamlNode(inputYaml)
+                    val output = Yaml.default.encodeToString(YamlNodeSerializer, node)
+
+                    test("preserves the string and does not convert to NaN") {
+                        output shouldBe """".nan""""
+                    }
+                }
+
+                context("single-quoted float string '2.71'") {
+                    val inputYaml = """'2.71'"""
+                    val node = Yaml.default.parseToYamlNode(inputYaml)
+                    val output = Yaml.default.encodeToString(YamlNodeSerializer, node)
+
+                    test("preserves the string and does not convert to float") {
+                        output shouldBe """'2.71'"""
+                    }
+                }
+            }
+
+            context("preserving tags on scalar values") {
+                context("tag !!str on integer content") {
+                    val inputYaml = """!!str 123"""
+                    val node = Yaml.default.parseToYamlNode(inputYaml)
+                    val output = Yaml.default.encodeToString(YamlNodeSerializer, node)
+
+                    test("preserves the tag and string content") {
+                        // The conversion is done by the [emitter.chooseScalarStyle] function that
+                        output shouldBe """!!str '123'"""
+                    }
+                }
+
+                context("tag !!str on boolean content") {
+                    val inputYaml = """!!str false"""
+                    val node = Yaml.default.parseToYamlNode(inputYaml)
+                    val output = Yaml.default.encodeToString(YamlNodeSerializer, node)
+
+                    test("preserves the tag and string content") {
+                        output shouldBe """!!str 'false'"""
+                    }
+                }
+
+                context("tag !!str on phone number with plus") {
+                    val inputYaml = """!!str +44123456"""
+                    val node = Yaml.default.parseToYamlNode(inputYaml)
+                    val output = Yaml.default.encodeToString(YamlNodeSerializer, node)
+
+                    test("preserves the tag and string content with plus sign") {
+                        output shouldBe """!!str '+44123456'"""
+                    }
+                }
+
+                context("custom tag on scalar value") {
+                    val inputYaml = """!customtag "value""""
+                    val node = Yaml.default.parseToYamlNode(inputYaml)
+                    val output = Yaml.default.encodeToString(YamlNodeSerializer, node)
+
+                    test("preserves the custom tag") {
+                        output shouldBe """!customtag "value""""
+                    }
+                }
+
+                context("tag !!str on float-like content") {
+                    val inputYaml = """!!str 3.14"""
+                    val node = Yaml.default.parseToYamlNode(inputYaml)
+                    val output = Yaml.default.encodeToString(YamlNodeSerializer, node)
+
+                    test("preserves the tag and string content") {
+                        output shouldBe """!!str '3.14'"""
+                    }
+                }
+            }
+
+            context("preserving tags on collections") {
+                context("tagged list") {
+                    val inputYaml = """
+                        !customlist
+                        - 1
+                        - 2
+                        - 3
+                    """.trimIndent()
+                    val node = Yaml.default.parseToYamlNode(inputYaml)
+                    val output = Yaml.default.encodeToString(YamlNodeSerializer, node)
+
+                    test("preserves the tag on the list") {
+                        output shouldBe """
+                            !customlist
+                            - 1
+                            - 2
+                            - 3
+                        """.trimIndent()
+                    }
+                }
+
+                context("tagged map") {
+                    val inputYaml = """
+                        !custommap
+                        key1: value1
+                        key2: value2
+                    """.trimIndent()
+                    val node = Yaml.default.parseToYamlNode(inputYaml)
+                    val output = Yaml.default.encodeToString(YamlNodeSerializer, node)
+
+                    test("preserves the tag on the map") {
+                        output shouldBe inputYaml
+                    }
+                }
+
+                context("list with tagged scalar items") {
+                    val inputYaml = """
+                        - !!str 123
+                        - !!str false
+                        - normal
+                    """.trimIndent()
+                    val node = Yaml.default.parseToYamlNode(inputYaml)
+                    val output = Yaml.default.encodeToString(YamlNodeSerializer, node)
+
+                    test("preserves tags on individual items") {
+                        output shouldBe """
+                            - !!str '123'
+                            - !!str 'false'
+                            - normal
+                        """.trimIndent()
+                    }
+                }
+
+                context("map with tagged scalar values") {
+                    val inputYaml = """
+                        key1: !!str 123
+                        key2: !!str false
+                        key3: normal
+                    """.trimIndent()
+                    val node = Yaml.default.parseToYamlNode(inputYaml)
+                    val output = Yaml.default.encodeToString(YamlNodeSerializer, node)
+
+                    test("preserves tags on individual values") {
+                        output shouldBe """
+                            key1: !!str '123'
+                            key2: !!str 'false'
+                            key3: normal
+                        """.trimIndent()
+                    }
+                }
+            }
+
+            context("preserving special YAML values as strings") {
+                context("double-quoted 'null' string") {
+                    val inputYaml = """"null""""
+                    val node = Yaml.default.parseToYamlNode(inputYaml)
+                    val output = Yaml.default.encodeToString(YamlNodeSerializer, node)
+
+                    test("preserves the string and does not convert to null") {
+                        output shouldBe """"null""""
+                    }
+                }
+
+                context("double-quoted tilde string") {
+                    val inputYaml = """"~""""
+                    val node = Yaml.default.parseToYamlNode(inputYaml)
+                    val output = Yaml.default.encodeToString(YamlNodeSerializer, node)
+
+                    test("preserves the string and does not convert to null") {
+                        output shouldBe """"~""""
+                    }
+                }
+
+                context("double-quoted dash string") {
+                    val inputYaml = """"-""""
+                    val node = Yaml.default.parseToYamlNode(inputYaml)
+                    val output = Yaml.default.encodeToString(YamlNodeSerializer, node)
+
+                    test("preserves the string") {
+                        output shouldBe """"-""""
+                    }
+                }
+
+                context("single-quoted 'null' string") {
+                    val inputYaml = """'null'"""
+                    val node = Yaml.default.parseToYamlNode(inputYaml)
+                    val output = Yaml.default.encodeToString(YamlNodeSerializer, node)
+
+                    test("preserves the string and does not convert to null") {
+                        output shouldBe """'null'"""
+                    }
+                }
+
+                context("double-quoted 'Null' string") {
+                    val inputYaml = """"Null""""
+                    val node = Yaml.default.parseToYamlNode(inputYaml)
+                    val output = Yaml.default.encodeToString(YamlNodeSerializer, node)
+
+                    test("preserves the string with casing") {
+                        output shouldBe """"Null""""
+                    }
+                }
+            }
+
+            context("preserving strings in complex structures") {
+                context("map with quoted boolean-like values") {
+                    val inputYaml = """
+                        enabled: "false"
+                        active: "true"
+                        count: "123"
+                    """.trimIndent()
+                    val node = Yaml.default.parseToYamlNode(inputYaml)
+                    val output = Yaml.default.encodeToString(YamlNodeSerializer, node)
+
+                    test("preserves all values as strings") {
+                        output shouldBe """
+                            enabled: "false"
+                            active: "true"
+                            count: "123"
+                        """.trimIndent()
+                    }
+                }
+
+                context("list with mixed quoted and unquoted values") {
+                    val inputYaml = """
+                        - "123"
+                        - 456
+                        - "false"
+                        - true
+                    """.trimIndent()
+                    val node = Yaml.default.parseToYamlNode(inputYaml)
+                    val output = Yaml.default.encodeToString(YamlNodeSerializer, node)
+
+                    test("preserves strings as strings and primitives as primitives") {
+                        output shouldBe """
+                            - "123"
+                            - 456
+                            - "false"
+                            - true
+                        """.trimIndent()
+                    }
+                }
+
+                context("nested structure with tagged and quoted values") {
+                    val inputYaml = """
+                        user:
+                          id: !!str 42
+                          active: "false"
+                          score: 3.14
+                    """.trimIndent()
+                    val node = Yaml.default.parseToYamlNode(inputYaml)
+                    val output = Yaml.default.encodeToString(YamlNodeSerializer, node)
+
+                    test("preserves tags and string types in nested structure") {
+                        output shouldBe """
+                            user:
+                              id: !!str '42'
+                              active: "false"
+                              score: 3.14
+                        """.trimIndent()
+                    }
+                }
+
+                context("list of maps with quoted string values") {
+                    val inputYaml = """
+                        - name: "item1"
+                          count: "100"
+                        - name: "item2"
+                          count: "200"
+                    """.trimIndent()
+                    val node = Yaml.default.parseToYamlNode(inputYaml)
+                    val output = Yaml.default.encodeToString(YamlNodeSerializer, node)
+
+                    test("preserves string types in list of maps") {
+                        output shouldBe """
+                            - name: "item1"
+                              count: "100"
+                            - name: "item2"
+                              count: "200"
+                        """.trimIndent()
+                    }
+                }
+            }
+
+            context("preserving different scalar styles") {
+                context("single-quoted scalar style") {
+                    val inputYaml = """'Hello World'"""
+                    val node = Yaml.default.parseToYamlNode(inputYaml)
+                    val output = Yaml.default.encodeToString(YamlNodeSerializer, node)
+
+                    test("preserves single-quoted style") {
+                        output shouldBe """'Hello World'"""
+                    }
+                }
+
+                context("double-quoted scalar style") {
+                    val inputYaml = """"Hello World""""
+                    val node = Yaml.default.parseToYamlNode(inputYaml)
+                    val output = Yaml.default.encodeToString(YamlNodeSerializer, node)
+
+                    test("preserves double-quoted style") {
+                        output shouldBe """"Hello World""""
+                    }
+                }
+
+                context("literal scalar style") {
+                    val inputYaml = """
+                        |
+                          Line 1
+                          Line 2
+                    """.trimIndent()
+                    val node = Yaml.default.parseToYamlNode(inputYaml)
+                    val output = Yaml.default.encodeToString(YamlNodeSerializer, node)
+
+                    test("preserves literal style for multiline content") {
+                        // Literal style should be preserved for multiline strings
+                        output shouldBe """
+                            |-
+                              Line 1
+                              Line 2
+                        """.trimIndent()
+                    }
+                }
+
+                context("folded scalar style") {
+                    val inputYaml = """
+                        >
+                          Folded line 1
+                          Folded line 2
+                    """.trimIndent()
+                    val node = Yaml.default.parseToYamlNode(inputYaml)
+                    val output = Yaml.default.encodeToString(YamlNodeSerializer, node)
+
+                    test("preserves folded style for multiline content") {
+                        // Folded style should be preserved for multiline strings
+                        output shouldBe """
+                            >-
+                              Folded line 1 Folded line 2
+                        """.trimIndent()
+                    }
                 }
             }
         }

--- a/src/jvmTest/kotlin/com/charleskorn/kaml/JvmYamlReadingTest.kt
+++ b/src/jvmTest/kotlin/com/charleskorn/kaml/JvmYamlReadingTest.kt
@@ -47,7 +47,7 @@ class JvmYamlReadingTest : DescribeSpec({
             val result = Yaml.default.parseToYamlNode(input)
 
             it("successfully deserializes values from a string") {
-                result shouldBe YamlScalar("123", YamlPath.root)
+                result shouldBe YamlScalar("123", YamlPath.root, YamlNodeScalarStyle.PLAIN)
             }
         }
 
@@ -56,7 +56,7 @@ class JvmYamlReadingTest : DescribeSpec({
             val result = Yaml.default.parseToYamlNode(input.byteInputStream())
 
             it("successfully deserializes values from a stream") {
-                result shouldBe YamlScalar("123", YamlPath.root)
+                result shouldBe YamlScalar("123", YamlPath.root, YamlNodeScalarStyle.PLAIN)
             }
         }
     }

--- a/src/jvmTest/kotlin/com/charleskorn/kaml/helpers/TestHelpers.kt
+++ b/src/jvmTest/kotlin/com/charleskorn/kaml/helpers/TestHelpers.kt
@@ -1,0 +1,42 @@
+/*
+
+   Copyright 2018-2023 Charles Korn.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+*/
+
+package com.charleskorn.kaml.helpers
+
+import com.charleskorn.kaml.YamlNodeScalarStyle
+import com.charleskorn.kaml.YamlPath
+import com.charleskorn.kaml.YamlScalar
+
+data class ResultWithStyle(
+    val content: String,
+    val style: YamlNodeScalarStyle,
+) {
+    override fun toString(): String {
+        return content
+    }
+
+    fun toYamlScalar(path: YamlPath): YamlScalar =
+        YamlScalar(this.content, path, this.style)
+}
+fun String.plain() = ResultWithStyle(this, YamlNodeScalarStyle.PLAIN)
+fun String.doubleQuoted() = ResultWithStyle(this, YamlNodeScalarStyle.DOUBLE_QUOTED)
+fun String.singleQuoted() = ResultWithStyle(this, YamlNodeScalarStyle.SINGLE_QUOTED)
+fun String.folded() = ResultWithStyle(this, YamlNodeScalarStyle.FOLDED)
+fun String.literal() = ResultWithStyle(this, YamlNodeScalarStyle.LITERAL)
+
+fun plainScalar(content: String, yamlPath: YamlPath) = YamlScalar(content, yamlPath, YamlNodeScalarStyle.PLAIN)


### PR DESCRIPTION
### Summary  
Fixes loss of scalar style and YAML tag information during round\-trip serialization of `YamlNode`s. Resolves issue https://github.com/charleskorn/kaml/issues/749.

### Problem  
Currently `YamlScalar` does not retain the original scalar style, making it impossible to distinguish between:
- A plain numeric scalar (e.g. 123)  
- A quoted string that looks like a number (e.g. "123")  
Additionally, YAML tags present in the parsed input were not emitted during serialization.

### Root cause  
- Scalar style (plain, single quoted, double quoted, literal, folded, JSON style) was not stored alongside the scalar value.  
- Serialization of `YamlNode` relied on generic Kotlinx Serialization paths that discarded style and tag metadata.

### Solution  
- Introduced preservation of scalar style via an explicit enum (`YamlNodeScalarStyle`) mapped to SnakeYAML engine styles.  
- Ensured YAML tags on nodes are carried through and emitted.  
- Delegated encoding of `YamlNode` subclasses to `YamlOutput`, separating it from standard Kotlinx Serialization logic to avoid interference and to centralize style/tag handling.

### Key changes   
- Updated serialization pipeline to include style and tag emission.  
- Adjusted `YamlOutput` to take responsibility for `YamlNode` encoding.  
- Added/updated tests to assert round\-trip fidelity for:  
  - Quoted vs plain numeric\-looking scalars  
  - Block scalar styles (literal, folded)  
  - Explicit tags  

Backward compatibility  
- Public API surface minimally affected (new enum exposed).  
- Existing consumers not relying on style/tag round\-tripping remain unaffected.  
- No breaking rename/removal of existing types.

Performance  
- Negligible impact; added metadata handling only during node serialization.

Risks / considerations  
- Consumers constructing `YamlScalar` programmatically may now wish to specify a style explicitly.  However, not specifying it results in original behavior.
- Ensure all new styles are covered in multiplatform targets. I tested all platforms except for tvosSimulatorArm64Test, please check.

Testing  
- Added unit tests for style preservation and tag emission.  
- Verified that previously failing scenario from issue \#749 now passes.

Closes: \#749

Let me know if a changelog entry format needs adjustment.